### PR TITLE
Ct checkout

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -9,12 +9,12 @@ The module also provides template scripts for post-deployment and pre-undeployme
 
 The Stripe customer session allows you to create a session for a customer, which can be used to manage their payment methods and subscriptions. This feature is particularly useful for businesses that want to provide a seamless checkout experience for their customers.
 
-To use the Stripe customer session, the customer who owns the cart in the commercetools Checkout session must have the `stripeCustomerId` in the custom field with a dummy value that will be updated with the Stripe Account ID created by the flow.
+To use the Stripe customer session, the customer who owns the cart in the commercetools Checkout session must have the `paymentConnectorStripeCustomerId` in the custom field.
 
 The creation and retrieval of the Stripe customer depend on a Custom Type created in the commercetools platform. This Custom Type should contain the following field:
-- **stripeCustomerId**: The ID of the customer in the commercetools platform or a dummy value.
+- **paymentConnectorStripeCustomerId**: The ID of the Stripe customer.
 
-If the `stripeCustomerId`, the connector will try to retrieve the Stripe customer, if the customer do not exist the connector will create a new customer in Stripe using the customer who owns the cart in the session. The customer ID will be stored in the metadata of the payment transaction in commercetools and the `stripeCustomerId` will be updated with the customer ID created in Stripe.
+If the `paymentConnectorStripeCustomerId` is presented, the connector will try to retrieve the Stripe customer, if the customer do not exist on Stripe, the connector will create a new customer in Stripe using the customer who owns the cart in the session. The commercetools customer ID will be stored in the metadata of the Stripe customer and the `paymentConnectorStripeCustomerId` field in commercetools will be updated with the Stripe customer ID .
 
 The environment variable `STRIPE_SAVED_PAYMENT_METHODS_CONFIG` configures the saved payment methods. The value needs to be a valid stringified JSON. More information about the properties can be found [here](https://docs.stripe.com/api/customer_sessions/object#customer_session_object-components-payment_element-features). This feature is disabled by default.
 

--- a/processor/src/routes/stripe-payment.route.ts
+++ b/processor/src/routes/stripe-payment.route.ts
@@ -42,6 +42,7 @@ export const customerRoutes = async (fastify: FastifyInstance, opts: FastifyPlug
       schema: {
         response: {
           200: CustomerResponseSchema,
+          204: Type.Null(),
         },
       },
     },

--- a/processor/test/services/converters/stripeEvent.converter.spec.ts
+++ b/processor/test/services/converters/stripeEvent.converter.spec.ts
@@ -6,6 +6,8 @@ import {
   mockEvent__paymentIntent_paymentFailed,
   mockEvent__paymentIntent_succeeded_captureMethodAutomatic,
   mockEvent__charge_succeeded_notCaptured,
+  mockEvent__charge_refund_notCaptured,
+  mockEvent__charge_succeeded_captured,
 } from '../../utils/mock-routes-data';
 
 describe('stripeEvent.converter', () => {
@@ -60,7 +62,7 @@ describe('stripeEvent.converter', () => {
     });
   });
 
-  test('convert a payment_intent.payment_failed event', () => {
+  test('convert a payment_intent.payment_failed event transaction', () => {
     const result = converter.convert(mockEvent__paymentIntent_paymentFailed);
 
     expect(result).toEqual({
@@ -80,7 +82,7 @@ describe('stripeEvent.converter', () => {
     });
   });
 
-  test('convert a payment_intent.payment_failed event', () => {
+  test('convert a charge.refunded event captured to transaction', () => {
     const result = converter.convert(mockEvent__charge_refund_captured);
 
     expect(result).toEqual({
@@ -110,6 +112,17 @@ describe('stripeEvent.converter', () => {
     });
   });
 
+  test('convert a charge.refunded event not captured to empty transaction', () => {
+    const result = converter.convert(mockEvent__charge_refund_notCaptured);
+
+    expect(result).toEqual({
+      id: 'pi_11111',
+      paymentMethod: 'payment',
+      pspReference: 'pi_11111',
+      transactions: [],
+    });
+  });
+
   test('convert a non supported event notification', () => {
     const event = mockEvent__charge_refund_captured;
     event.type = 'account.application.deauthorized';
@@ -121,10 +134,21 @@ describe('stripeEvent.converter', () => {
     }
   });
 
-  test('convert a charge.succeeded event', () => {
+  test('convert a charge.succeeded event not captured return empty array', () => {
+    const result = converter.convert(mockEvent__charge_succeeded_captured);
+
+    expect(result).toEqual({
+      paymentMethod: 'payment',
+      pspReference: 'pi_11111',
+      transactions: [],
+    });
+  });
+
+  test('convert a charge.succeeded event captured return transaction', () => {
     const result = converter.convert(mockEvent__charge_succeeded_notCaptured);
 
     expect(result).toEqual({
+      id: 'pi_11111',
       paymentMethod: 'payment',
       pspReference: 'pi_11111',
       transactions: [

--- a/processor/test/services/stripe-payment.service.spec.ts
+++ b/processor/test/services/stripe-payment.service.spec.ts
@@ -580,6 +580,9 @@ describe('stripe-payment.service', () => {
       const getCtCustomerMock = jest
         .spyOn(StripePaymentService.prototype, 'getCtCustomer')
         .mockResolvedValue(mockCtCustomerData);
+      const getIsStripeCustomerIdFieldPresent = jest
+        .spyOn(StripePaymentService.prototype, 'isStripeCustomerIdFieldPresent')
+        .mockResolvedValue(true);
       const getStripeCustomerIdMock = jest
         .spyOn(StripePaymentService.prototype, 'getStripeCustomerId')
         .mockResolvedValue(mockStripeCustomerId);
@@ -604,6 +607,7 @@ describe('stripe-payment.service', () => {
 
       expect(getCartMock).toHaveBeenCalled();
       expect(getCtCustomerMock).toHaveBeenCalled();
+      expect(getIsStripeCustomerIdFieldPresent).toHaveBeenCalled();
       expect(getStripeCustomerIdMock).toHaveBeenCalled();
       expect(saveCustomerMock).toHaveBeenCalled();
       expect(createEphemeralKeyMock).toHaveBeenCalled();
@@ -628,12 +632,16 @@ describe('stripe-payment.service', () => {
       const getCtCustomerMock = jest
         .spyOn(StripePaymentService.prototype, 'getCtCustomer')
         .mockResolvedValue(mockCtCustomerWithoutCustomFieldsData);
+      const getIsStripeCustomerIdFieldPresent = jest
+        .spyOn(StripePaymentService.prototype, 'isStripeCustomerIdFieldPresent')
+        .mockResolvedValue(false);
 
       const response = await stripePaymentService.getCustomerSession();
 
       expect(response).toBeUndefined();
       expect(Logger.log.warn).toBeCalled();
       expect(getCartMock).toHaveBeenCalled();
+      expect(getIsStripeCustomerIdFieldPresent).toHaveBeenCalled();
       expect(getCtCustomerMock).toHaveBeenCalled();
     });
 
@@ -644,6 +652,9 @@ describe('stripe-payment.service', () => {
       const getCtCustomerMock = jest
         .spyOn(StripePaymentService.prototype, 'getCtCustomer')
         .mockResolvedValue(mockCtCustomerData);
+      const getIsStripeCustomerIdFieldPresent = jest
+        .spyOn(StripePaymentService.prototype, 'isStripeCustomerIdFieldPresent')
+        .mockResolvedValue(true);
       const getStripeCustomerIdMock = jest
         .spyOn(StripePaymentService.prototype, 'getStripeCustomerId')
         .mockResolvedValue(undefined);
@@ -656,6 +667,7 @@ describe('stripe-payment.service', () => {
 
       expect(getCartMock).toHaveBeenCalled();
       expect(getCtCustomerMock).toHaveBeenCalled();
+      expect(getIsStripeCustomerIdFieldPresent).toHaveBeenCalled();
       expect(getStripeCustomerIdMock).toHaveBeenCalled();
     });
 
@@ -666,6 +678,9 @@ describe('stripe-payment.service', () => {
       const getCtCustomerMock = jest
         .spyOn(StripePaymentService.prototype, 'getCtCustomer')
         .mockResolvedValue(mockCtCustomerData);
+      const getIsStripeCustomerIdFieldPresent = jest
+        .spyOn(StripePaymentService.prototype, 'isStripeCustomerIdFieldPresent')
+        .mockResolvedValue(true);
       const getStripeCustomerIdMock = jest
         .spyOn(StripePaymentService.prototype, 'getStripeCustomerId')
         .mockResolvedValue(mockStripeCustomerId);
@@ -681,6 +696,7 @@ describe('stripe-payment.service', () => {
 
       expect(getCartMock).toHaveBeenCalled();
       expect(getCtCustomerMock).toHaveBeenCalled();
+      expect(getIsStripeCustomerIdFieldPresent).toHaveBeenCalled();
       expect(getStripeCustomerIdMock).toHaveBeenCalled();
       expect(saveCustomerMock).toHaveBeenCalled();
     });
@@ -692,6 +708,9 @@ describe('stripe-payment.service', () => {
       const getCtCustomerMock = jest
         .spyOn(StripePaymentService.prototype, 'getCtCustomer')
         .mockResolvedValue(mockCtCustomerData);
+      const getIsStripeCustomerIdFieldPresent = jest
+        .spyOn(StripePaymentService.prototype, 'isStripeCustomerIdFieldPresent')
+        .mockResolvedValue(true);
       const getStripeCustomerIdMock = jest
         .spyOn(StripePaymentService.prototype, 'getStripeCustomerId')
         .mockResolvedValue(mockStripeCustomerId);
@@ -710,6 +729,7 @@ describe('stripe-payment.service', () => {
 
       expect(getCartMock).toHaveBeenCalled();
       expect(getCtCustomerMock).toHaveBeenCalled();
+      expect(getIsStripeCustomerIdFieldPresent).toHaveBeenCalled();
       expect(getStripeCustomerIdMock).toHaveBeenCalled();
       expect(saveCustomerMock).toHaveBeenCalled();
       expect(createEphemeralKeyMock).toHaveBeenCalled();
@@ -722,6 +742,9 @@ describe('stripe-payment.service', () => {
       const getCustomerMock = jest
         .spyOn(StripePaymentService.prototype, 'getCtCustomer')
         .mockResolvedValue(mockCtCustomerData);
+      const getIsStripeCustomerIdFieldPresent = jest
+        .spyOn(StripePaymentService.prototype, 'isStripeCustomerIdFieldPresent')
+        .mockResolvedValue(true);
       const getStripeCustomerIdMock = jest
         .spyOn(StripePaymentService.prototype, 'getStripeCustomerId')
         .mockResolvedValue(mockStripeCustomerId);
@@ -743,6 +766,7 @@ describe('stripe-payment.service', () => {
 
       expect(getCartMock).toHaveBeenCalled();
       expect(getCustomerMock).toHaveBeenCalled();
+      expect(getIsStripeCustomerIdFieldPresent).toHaveBeenCalled();
       expect(getStripeCustomerIdMock).toHaveBeenCalled();
       expect(saveCustomerMock).toHaveBeenCalled();
       expect(createEphemeralKeyMock).toHaveBeenCalled();

--- a/processor/test/utils/mock-customer-data.ts
+++ b/processor/test/utils/mock-customer-data.ts
@@ -92,7 +92,7 @@ export const mockCtCustomerData: Customer = {
       id: 'xxxxxxxxxxx',
     },
     fields: {
-      stripeCustomerId: 'cus_Example',
+      paymentConnectorStripeCustomerId: 'cus_Example',
     },
   },
 };

--- a/processor/test/utils/mock-routes-data.ts
+++ b/processor/test/utils/mock-routes-data.ts
@@ -693,6 +693,7 @@ export const mockEvent__charge_succeeded_notCaptured: Stripe.Event = {
       livemode: false,
       metadata: {
         cart_id: '11111-22222',
+        ct_payment_id: 'pi_11111',
       },
       on_behalf_of: null,
       outcome: {
@@ -806,7 +807,7 @@ export const mockEvent__charge_succeeded_captured: Stripe.Event = {
     id: 'req_11111',
     idempotency_key: '7ae634ca-11111',
   },
-  type: 'charge.captured',
+  type: 'charge.succeeded',
 };
 
 export const mockEvent__paymentIntent_requiresAction: Stripe.Event = {


### PR DESCRIPTION
This pull request focuses on updating the Stripe customer ID field and ensuring consistency across various files and tests. The main changes include renaming the custom field for the Stripe customer ID, updating related methods, and adding new test cases.

Key changes:

### Field Renaming and Consistency:
* [`processor/README.md`](diffhunk://#diff-3a2ddbdc16a92eff5e1bf00f9e3e2380496df73a8a0e03b07ea176a3374b45e5L12-R17): Updated the custom field name from `stripeCustomerId` to `paymentConnectorStripeCustomerId` and revised related descriptions.
* [`processor/src/services/stripe-payment.service.ts`](diffhunk://#diff-f4052bff6b64be96550a6f02f1addb189981ef5f87ab5bc20cdc74f1b275c1acL238-R246): Renamed `stripeCustomerId` to `paymentConnectorStripeCustomerId` in various methods, including `getStripeCustomerId` and `saveStripeCustomerId`. [[1]](diffhunk://#diff-f4052bff6b64be96550a6f02f1addb189981ef5f87ab5bc20cdc74f1b275c1acL238-R246) [[2]](diffhunk://#diff-f4052bff6b64be96550a6f02f1addb189981ef5f87ab5bc20cdc74f1b275c1acL523-R524) [[3]](diffhunk://#diff-f4052bff6b64be96550a6f02f1addb189981ef5f87ab5bc20cdc74f1b275c1acL592-R599) [[4]](diffhunk://#diff-f4052bff6b64be96550a6f02f1addb189981ef5f87ab5bc20cdc74f1b275c1acR656-R667)

### New Methods:
* [`processor/src/services/stripe-payment.service.ts`](diffhunk://#diff-f4052bff6b64be96550a6f02f1addb189981ef5f87ab5bc20cdc74f1b275c1acR656-R667): Added a new method `isStripeCustomerIdFieldPresent` to check for the presence of the custom field `paymentConnectorStripeCustomerId`.

### Test Updates:
* [`processor/test/services/converters/stripeEvent.converter.spec.ts`](diffhunk://#diff-8c7ce5bbd3cb85a5300a2d94220a93a6cb44c9b45a974daeb0da9a290898973eL63-R65): Added new test cases for handling different Stripe events, including `charge.refunded` and `charge.succeeded`. [[1]](diffhunk://#diff-8c7ce5bbd3cb85a5300a2d94220a93a6cb44c9b45a974daeb0da9a290898973eL63-R65) [[2]](diffhunk://#diff-8c7ce5bbd3cb85a5300a2d94220a93a6cb44c9b45a974daeb0da9a290898973eL83-R85) [[3]](diffhunk://#diff-8c7ce5bbd3cb85a5300a2d94220a93a6cb44c9b45a974daeb0da9a290898973eR115-R125) [[4]](diffhunk://#diff-8c7ce5bbd3cb85a5300a2d94220a93a6cb44c9b45a974daeb0da9a290898973eL124-R151)
* [`processor/test/services/stripe-payment.service.spec.ts`](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R583-R585): Updated existing tests and added new ones to check the presence of the `paymentConnectorStripeCustomerId` field. [[1]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R583-R585) [[2]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R610) [[3]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R635-R644) [[4]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R655-R657) [[5]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R681-R683) [[6]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R699) [[7]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R711-R713) [[8]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R745-R747) [[9]](diffhunk://#diff-1063ec6ed2c7d9be520214a5c60cb6b3e586312cab050fa3a39b5d3f28382f11R769)
* [`processor/test/utils/mock-customer-data.ts`](diffhunk://#diff-96c8a90c89681423fe00bf683384d4495406f2222d709ed287fa89d4aa52e95dL95-R95): Updated mock data to reflect the new custom field name.
* [`processor/test/utils/mock-routes-data.ts`](diffhunk://#diff-fe2f64ce5cb2e214663ccc6c1781540ef6920c6acce43a479a89afd7a2ee542eR696): Added new mock events and updated existing ones for consistency with the new field name. [[1]](diffhunk://#diff-fe2f64ce5cb2e214663ccc6c1781540ef6920c6acce43a479a89afd7a2ee542eR696) [[2]](diffhunk://#diff-fe2f64ce5cb2e214663ccc6c1781540ef6920c6acce43a479a89afd7a2ee542eL809-R810)

### Minor Changes:
* [`processor/src/routes/stripe-payment.route.ts`](diffhunk://#diff-eb1dee40bbbc15e0d0bd93a3ef6ee96220c27969a851f28c1ac9e90c05b3d8c6R45): Added a 204 response schema for customer routes.