### PR TITLE
fix(express): read shipping/billing from confirm event instead of internal element properties

### DIFF
--- a/enabler/src/express/dropin-express.ts
+++ b/enabler/src/express/dropin-express.ts
@@ -12,6 +12,7 @@ import {
   LineItem,
   StripeExpressCheckoutElement,
   StripeExpressCheckoutElementClickEvent,
+  StripeExpressCheckoutElementConfirmEvent,
 } from '@stripe/stripe-js';
 import { PaymentResponseSchemaDTO } from '../dtos/mock-payment.dto';
 
@@ -199,8 +200,8 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
       this.kickOffSessionInitFromClick();
     });
 
-    el.on('confirm', async () => {
-      await this.handlePaymentConfirm();
+    el.on('confirm', async (event: StripeExpressCheckoutElementConfirmEvent) => {
+      await this.handlePaymentConfirm(event);
     });
 
     el.on('cancel', () => {
@@ -382,11 +383,15 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
    * Handles payment confirmation when the user authorizes payment in Express Checkout.
    * Triggered by the `confirm` event from `StripeExpressCheckoutElement`.
    *
+   * @param event - The confirm event from `StripeExpressCheckoutElement`, which carries
+   *   `billingDetails` and `shippingAddress` from the wallet (available when
+   *   `billingAddressRequired` / `shippingAddressRequired` are set on the element).
+   *
    * @remarks
    * Flow: submit Elements → optional sync via `onPaymentSubmit` (partial payload only) →
    * create PaymentIntent on the processor → confirm with Stripe → persist in commercetools → `onComplete`.
    */
-  private async handlePaymentConfirm(): Promise<void> {
+  private async handlePaymentConfirm(event: StripeExpressCheckoutElementConfirmEvent): Promise<void> {
     try {
       await this.ensureSessionId();
 
@@ -397,24 +402,15 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
         throw submitError;
       }
 
-      // Step 2: Read shipping/billing from the Express element when Stripe exposes them.
-      let shippingAddress: any = null;
-      let billingAddress: any = null;
-      try {
-        shippingAddress = this.getShippingAddressFromStripe();
-        billingAddress = this.getBillingAddressFromStripe();
-      } catch {
-        // Element may not expose addresses; cart may already be updated from prior shipping events.
-      }
-
-      // Step 3: Integrator callback — sync checkout/cart only for fields the wallet exposed.
-      const expressShipping = shippingAddress
-        ? this.convertToExpressAddress(shippingAddress)
+      // Step 2: Read shipping/billing directly from the confirm event (official Stripe API).
+      // Both fields are present when shippingAddressRequired / billingAddressRequired are set.
+      const expressShipping = event.shippingAddress
+        ? this.convertToExpressAddress(event.shippingAddress)
         : ({} as ExpressAddressData);
-      const expressBilling = billingAddress
-        ? this.convertToExpressAddress(billingAddress)
+      const expressBilling = event.billingDetails
+        ? this.convertToExpressAddress(event.billingDetails)
         : ({} as ExpressAddressData);
-      const customerEmail = expressBilling?.email ?? expressShipping?.email ?? '';
+      const customerEmail = event.billingDetails?.email ?? expressShipping?.email ?? '';
       const paymentSubmitPayload = this.buildExpressPaymentSubmitPayload(
         expressShipping,
         expressBilling,
@@ -433,8 +429,8 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
         cartId: paymentRes.cartId,
         clientSecret: paymentRes.sClientSecret,
         paymentReference: paymentRes.paymentReference,
-        ...(billingAddress && {
-          billingAddress: this.convertStripeAddressToBillingAddress(billingAddress),
+        ...(event.billingDetails && {
+          billingAddress: this.convertStripeAddressToBillingAddress(event.billingDetails),
         }),
       });
 
@@ -570,32 +566,6 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
       headers['x-express-checkout'] = 'true';
     }
     return headers;
-  }
-
-  /**
-   * Gets shipping address from Stripe ExpressCheckoutElement.
-   * This is available after the user selects an address in the Express Checkout modal.
-   */
-  private getShippingAddressFromStripe(): any {
-    // Access the last shipping address from the element
-    // Note: This is an internal property that may not be in type definitions
-    const value = (this.expressCheckoutElement as any)?._lastShippingAddress ||
-      (this.expressCheckoutElement as any)?.lastShippingAddress ||
-      null;
-    return value;
-  }
-
-  /**
-   * Gets billing address from Stripe ExpressCheckoutElement.
-   * This is available after the user authorizes payment.
-   */
-  private getBillingAddressFromStripe(): any {
-    // Access the last billing address from the element
-    // Note: This is an internal property that may not be in type definitions
-    const value = (this.expressCheckoutElement as any)?._lastBillingAddress ||
-      (this.expressCheckoutElement as any)?.lastBillingAddress ||
-      null;
-    return value;
   }
 
   /**

--- a/enabler/test/express/stripe-express.spec.ts
+++ b/enabler/test/express/stripe-express.spec.ts
@@ -505,10 +505,12 @@ describe('StripeExpressComponent', () => {
 
     /**
      * Mounts Express with a confirm handler wired; `elements.submit` and `sdk.confirmPayment` mocked.
+     * The returned `confirmHandler` accepts a `StripeExpressCheckoutElementConfirmEvent`-shaped object
+     * so each test can supply exactly the address data the wallet would expose.
      */
-    async function mountWithConfirmHandler(elementProps?: Record<string, unknown>) {
-      let confirmHandler: (() => Promise<void>) | null = null;
-      const mockOn = jest.fn((event: string, handler: () => Promise<void>) => {
+    async function mountWithConfirmHandler() {
+      let confirmHandler: ((event: any) => Promise<void>) | null = null;
+      const mockOn = jest.fn((event: string, handler: (e: any) => Promise<void>) => {
         if (event === 'confirm') confirmHandler = handler;
       });
       const mockElement = {
@@ -516,7 +518,6 @@ describe('StripeExpressComponent', () => {
         unmount: jest.fn(),
         update: jest.fn(),
         on: mockOn,
-        ...elementProps,
       };
       const mockSubmit = jest.fn().mockResolvedValue({});
       const mockElements = {
@@ -571,19 +572,19 @@ describe('StripeExpressComponent', () => {
 
     test('does not call onPaymentSubmit when wallet exposes no address or email', async () => {
       const { expressOptions, confirmHandler } = await mountWithConfirmHandler();
-      await confirmHandler();
+      await confirmHandler({});
       await new Promise<void>((r) => setImmediate(r));
       expect(expressOptions.onPaymentSubmit).not.toHaveBeenCalled();
     });
 
     test('calls onPaymentSubmit with billingAddress only when shipping is absent', async () => {
-      const { expressOptions, confirmHandler } = await mountWithConfirmHandler({
-        _lastBillingAddress: {
-          address: { country: 'DE', line1: '1 Hauptstraße' },
+      const { expressOptions, confirmHandler } = await mountWithConfirmHandler();
+      await confirmHandler({
+        billingDetails: {
           email: 'buyer@example.com',
+          address: { country: 'DE', line1: '1 Hauptstraße' },
         },
       });
-      await confirmHandler();
       await new Promise<void>((r) => setImmediate(r));
       expect(expressOptions.onPaymentSubmit).toHaveBeenCalledTimes(1);
       const payload = (expressOptions.onPaymentSubmit as jest.Mock).mock.calls[0][0];
@@ -595,13 +596,13 @@ describe('StripeExpressComponent', () => {
     });
 
     test('calls onPaymentSubmit with customerEmail only when addresses have no country', async () => {
-      const { expressOptions, confirmHandler } = await mountWithConfirmHandler({
-        _lastBillingAddress: {
+      const { expressOptions, confirmHandler } = await mountWithConfirmHandler();
+      await confirmHandler({
+        billingDetails: {
           email: 'only@email.test',
           address: {},
         },
       });
-      await confirmHandler();
       await new Promise<void>((r) => setImmediate(r));
       expect(expressOptions.onPaymentSubmit).toHaveBeenCalledTimes(1);
       const payload = (expressOptions.onPaymentSubmit as jest.Mock).mock.calls[0][0];

--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -16,7 +16,7 @@
         "@fastify/formbody": "8.0.2",
         "@fastify/http-proxy": "^11.4.4",
         "@fastify/request-context": "6.2.1",
-        "@fastify/static": "8.2.0",
+        "@fastify/static": "^9.1.3",
         "@fastify/type-provider-typebox": "5.2.0",
         "@sinclair/typebox": "0.34.41",
         "dotenv": "17.2.2",
@@ -1219,9 +1219,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-8.2.0.tgz",
-      "integrity": "sha512-PejC/DtT7p1yo3p+W7LiUtLMsV8fEvxAK15sozHy9t8kwo5r0uLYmhV/inURmGz1SkHZFz/8CNtHLPyhKcx4SQ==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
+      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
       "funding": [
         {
           "type": "github",
@@ -1236,10 +1236,10 @@
       "dependencies": {
         "@fastify/accept-negotiator": "^2.0.0",
         "@fastify/send": "^4.0.0",
-        "content-disposition": "^0.5.4",
+        "content-disposition": "^1.0.1",
         "fastify-plugin": "^5.0.0",
         "fastq": "^1.17.1",
-        "glob": "^11.0.0"
+        "glob": "^13.0.0"
       }
     },
     "node_modules/@fastify/type-provider-typebox": {
@@ -1403,6 +1403,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1420,6 +1421,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1432,6 +1434,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1444,12 +1447,14 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -1467,6 +1472,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1482,6 +1488,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -3591,6 +3598,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4417,13 +4425,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/convert-source-map": {
@@ -4459,6 +4470,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4682,6 +4694,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -4715,6 +4728,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/enabled": {
@@ -5802,6 +5816,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -5818,6 +5833,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5992,23 +6008,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6519,6 +6529,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6787,6 +6798,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6879,21 +6891,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest": {
@@ -9553,6 +9550,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -9595,6 +9593,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10321,6 +10320,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10331,6 +10331,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10564,6 +10565,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10579,6 +10581,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10650,6 +10653,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10663,6 +10667,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10771,24 +10776,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-hex": {
@@ -11355,6 +11342,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11514,6 +11502,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -11531,6 +11520,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11546,6 +11536,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11558,6 +11549,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {

--- a/processor/package.json
+++ b/processor/package.json
@@ -27,7 +27,7 @@
     "@fastify/formbody": "8.0.2",
     "@fastify/http-proxy": "^11.4.4",
     "@fastify/request-context": "6.2.1",
-    "@fastify/static": "8.2.0",
+    "@fastify/static": "^9.1.3",
     "@fastify/type-provider-typebox": "5.2.0",
     "@sinclair/typebox": "0.34.41",
     "dotenv": "17.2.2",


### PR DESCRIPTION
Replace the brittle `_lastShippingAddress`/`_lastBillingAddress` internal property access with the official `StripeExpressCheckoutElementConfirmEvent` payload.

- Pass the `confirm` event to `handlePaymentConfirm` and read `event.shippingAddress` / `event.billingDetails` directly
- Remove `getShippingAddressFromStripe` and `getBillingAddressFromStripe` helpers that relied on undocumented internal properties
- Update tests: `mountWithConfirmHandler` no longer accepts `elementProps`; each test now passes a typed event object directly to `confirmHandler`
- Bump `@fastify/static` from 8.2.0 to ^9.1.3 (and update lock file accordingly)