### PR TITLE
feat(enabler): add locale converter and forward locale to Stripe Elements

### DIFF
--- a/enabler/package-lock.json
+++ b/enabler/package-lock.json
@@ -4184,9 +4184,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -4196,8 +4196,7 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",

--- a/enabler/src/converters/locale.converter.ts
+++ b/enabler/src/converters/locale.converter.ts
@@ -1,0 +1,134 @@
+import type { StripeElementLocale } from '@stripe/stripe-js';
+
+/**
+ * Subset of Stripe-supported `StripeElementLocale` values excluding `"auto"`.
+ *
+ * Source of truth: `StripeElementLocale` exported from `@stripe/stripe-js`.
+ * Listed explicitly (rather than derived) so the array is iterable at runtime
+ * and the type system enforces that every entry is a valid Stripe locale.
+ *
+ * If the installed `@stripe/stripe-js` adds or removes locales, this array
+ * must be updated to match. TypeScript will surface mismatches at compile time.
+ */
+const supportedLocales: ReadonlyArray<Exclude<StripeElementLocale, 'auto'>> = [
+  'ar',
+  'bg',
+  'cs',
+  'da',
+  'de',
+  'el',
+  'en',
+  'en-AU',
+  'en-CA',
+  'en-NZ',
+  'en-GB',
+  'es',
+  'es-ES',
+  'es-419',
+  'et',
+  'fi',
+  'fil',
+  'fr',
+  'fr-CA',
+  'fr-FR',
+  'he',
+  'hu',
+  'hr',
+  'id',
+  'it',
+  'it-IT',
+  'ja',
+  'ko',
+  'lt',
+  'lv',
+  'ms',
+  'mt',
+  'nb',
+  'nl',
+  'no',
+  'pl',
+  'pt',
+  'pt-BR',
+  'ro',
+  'ru',
+  'sk',
+  'sl',
+  'sv',
+  'th',
+  'tr',
+  'vi',
+  'zh',
+  'zh-HK',
+  'zh-TW',
+];
+
+/**
+ * Optional explicit mapping from arbitrary host locale strings to Stripe locales.
+ *
+ * Kept empty by default — extension point matching the Adyen connector pattern.
+ * Add entries here when a host locale needs to map to a specific Stripe locale
+ * that the algorithm below would not pick (e.g. mapping `"es-MX"` to `"es-419"`
+ * if Latin-American Spanish becomes the preferred default for LATAM inputs).
+ */
+const localeToStripeLocaleMapping: Readonly<Record<string, StripeElementLocale>> = {};
+
+/**
+ * Converts an arbitrary locale string from the host storefront into a valid
+ * `StripeElementLocale` for `stripeSDK.elements({ locale })`.
+ *
+ * Input format: BCP-47-ish. Accepts `xx`, `xx-YY`, `xx_YY`, any case
+ * (`"es"`, `"es-MX"`, `"ES_mx"`, `"EN-gb"`).
+ *
+ * Output: always a valid `StripeElementLocale`. When the input cannot be
+ * matched, returns `"auto"` — Stripe's native fallback that defers to the
+ * browser's locale. `"auto"` is intentional (behavior-preserving): omitting
+ * `locale` from `elements()` produces the same `"auto"` behavior, so
+ * unrecognized inputs do not regress existing behavior.
+ *
+ * Resolution order:
+ *   1. Falsy or whitespace-only input → `"auto"`.
+ *   2. Explicit `localeToStripeLocaleMapping` entry (case-insensitive).
+ *   3. Exact case-insensitive match in `supportedLocales` (returns the
+ *      canonical-cased supported code, e.g. `"EN-gb"` → `"en-GB"`).
+ *   4. Base-language exact match (e.g. `"de_DE"` → `"de"`, `"es-MX"` → `"es"`).
+ *      This step preferences region-less variants so `"es-MX"` resolves to
+ *      `"es"` (predictable Adyen-pattern parity) rather than `"es-419"`.
+ *   5. Region-prefix scan: first supported locale whose lowercased form
+ *      starts with `baseLocale + "-"` (e.g. `"zh-CN"` would match `"zh-HK"`
+ *      if `"zh"` were not in the list — in practice step 4 catches this).
+ *   6. Fallback → `"auto"`.
+ *
+ * @param locale - Host locale string (e.g. `"es-MX"`, `"fr_FR"`, `"pt"`).
+ * @returns A valid `StripeElementLocale`, defaulting to `"auto"`.
+ */
+export const convertToStripeLocale = (locale?: string): StripeElementLocale => {
+  if (!locale || !locale.trim()) {
+    return 'auto';
+  }
+
+  const normalized = locale.trim().replace(/_/g, '-').toLowerCase();
+
+  const explicit = localeToStripeLocaleMapping[normalized];
+  if (explicit) {
+    return explicit;
+  }
+
+  const exact = supportedLocales.find((code) => code.toLowerCase() === normalized);
+  if (exact) {
+    return exact;
+  }
+
+  const baseLocale = normalized.split('-')[0];
+  const baseExact = supportedLocales.find((code) => code.toLowerCase() === baseLocale);
+  if (baseExact) {
+    return baseExact;
+  }
+
+  const prefix = `${baseLocale}-`;
+  const prefixMatch = supportedLocales.find((code) => code.toLowerCase().startsWith(prefix));
+  if (prefixMatch) {
+    return prefixMatch;
+  }
+
+  return 'auto';
+};

--- a/enabler/src/express/dropin-express.ts
+++ b/enabler/src/express/dropin-express.ts
@@ -108,6 +108,8 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
 
     if (this.baseOptions.elements) {
       // With session: Elements already created by _Setup with cart data — update to initialAmount.
+      // `locale` is intentionally NOT passed: Stripe Elements ignores `locale` in `update()`,
+      // so it must be set at creation. `_Setup` already applied the converted locale.
       this.baseOptions.elements.update({
         amount: centAmount,
         ...(currency && { currency }),
@@ -120,6 +122,7 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
         currency,
         capture_method: (this.baseOptions.captureMethod ?? 'automatic') as any,
         ...(this.baseOptions.appearance && { appearance: this.baseOptions.appearance }),
+        ...(this.baseOptions.locale && { locale: this.baseOptions.locale }),
       });
     }
 

--- a/enabler/src/payment-enabler/payment-enabler-mock.ts
+++ b/enabler/src/payment-enabler/payment-enabler-mock.ts
@@ -15,7 +15,8 @@ import {
   StripeElements,
   StripePaymentElementOptions
 } from "@stripe/stripe-js";
-import type { StripeExpressCheckoutElementOptions } from "@stripe/stripe-js";
+import type { StripeElementLocale, StripeExpressCheckoutElementOptions } from "@stripe/stripe-js";
+import { convertToStripeLocale } from "../converters/locale.converter";
 
 export type ExpressElementOptions = Pick<
   StripeExpressCheckoutElementOptions,
@@ -45,7 +46,7 @@ export type BaseOptions = {
   environment: string;
   processorUrl: string;
   sessionId: string;
-  locale?: string;
+  locale?: StripeElementLocale;
   onComplete: (result: PaymentResult) => void;
   onError: (error?: any) => void;
   paymentElement: StripePaymentElement; // MVP https://docs.stripe.com/payments/payment-element
@@ -107,7 +108,8 @@ export class MockPaymentEnabler implements PaymentEnabler {
     const [cartInfoResponse, configEnvResponse] = await MockPaymentEnabler.fetchConfigData(paymentMethodType, options);
     const stripeSDK = await MockPaymentEnabler.getStripeSDK(configEnvResponse);
     const customer = await MockPaymentEnabler.getCustomerOptions(options);
-    const elements = MockPaymentEnabler.getElements(stripeSDK, cartInfoResponse, customer);
+    const locale = convertToStripeLocale(options.locale);
+    const elements = MockPaymentEnabler.getElements(stripeSDK, cartInfoResponse, customer, locale);
     const elementsOptions = MockPaymentEnabler.getElementsOptions(options, cartInfoResponse);
 
     return Promise.resolve({
@@ -116,6 +118,7 @@ export class MockPaymentEnabler implements PaymentEnabler {
         environment: configEnvResponse.publishableKey.includes("_test_") ? "test" : configEnvResponse.environment, // MVP do we get this from the env of processor? or we leave the responsability to the publishableKey from Stripe?
         processorUrl: options.processorUrl,
         sessionId: options.sessionId,
+        locale,
         onComplete: options.onComplete || (() => {}),
         onError: options.onError || (() => {}),
         paymentElement: elements.create('payment', elementsOptions as StripePaymentElementOptions ),// MVP this could be expressCheckout or payment for subscritpion.
@@ -199,7 +202,8 @@ export class MockPaymentEnabler implements PaymentEnabler {
   private static getElements(
     stripeSDK: Stripe | null,
     cartInfoResponse: ConfigElementResponseSchemaDTO,
-    customer: CustomerResponseSchemaDTO
+    customer: CustomerResponseSchemaDTO,
+    locale?: StripeElementLocale
   ): StripeElements | null {
     if (!stripeSDK) return null;
     try {
@@ -217,6 +221,7 @@ export class MockPaymentEnabler implements PaymentEnabler {
         }),
         appearance: parseJSON(cartInfoResponse.appearance),
         capture_method: cartInfoResponse.captureMethod,
+        ...(locale && { locale }),
       });
     } catch (error) {
       console.error("Error initializing elements:", error);
@@ -249,12 +254,14 @@ export class MockPaymentEnabler implements PaymentEnabler {
     const environment = configEnvResponse.publishableKey.includes('_test_')
       ? 'test'
       : configEnvResponse.environment;
+    const locale = convertToStripeLocale(options.locale);
     return {
       baseOptions: {
         sdk: stripeSDK,
         environment,
         processorUrl: options.processorUrl,
         sessionId: options.sessionId,
+        locale,
         onComplete: options.onComplete || (() => {}),
         onError: options.onError || (() => {}),
         paymentElement: null as unknown as StripePaymentElement,

--- a/enabler/test/converters/locale.converter.spec.ts
+++ b/enabler/test/converters/locale.converter.spec.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from '@jest/globals';
+import { convertToStripeLocale } from '../../src/converters/locale.converter';
+
+describe('convertToStripeLocale', () => {
+  describe('exact match', () => {
+    test.each([
+      ['en-GB', 'en-GB'],
+      ['pt-BR', 'pt-BR'],
+      ['zh-HK', 'zh-HK'],
+      ['fr-CA', 'fr-CA'],
+      ['es-419', 'es-419'],
+    ])('preserves canonical case for %s', (input, expected) => {
+      expect(convertToStripeLocale(input)).toBe(expected);
+    });
+  });
+
+  describe('case insensitive', () => {
+    test('lowercases input then matches canonical-cased supported code', () => {
+      expect(convertToStripeLocale('EN-gb')).toBe('en-GB');
+    });
+
+    test('matches base-language code case-insensitively', () => {
+      expect(convertToStripeLocale('EN')).toBe('en');
+    });
+  });
+
+  describe('underscore normalization', () => {
+    test('treats underscore as hyphen and resolves to base when region not supported', () => {
+      // Stripe has no `de-DE`, so `de_DE` should fall back to base-language `de`.
+      expect(convertToStripeLocale('de_DE')).toBe('de');
+    });
+
+    test('treats underscore as hyphen for exact-supported region variants', () => {
+      // Stripe supports `fr-CA`, so `fr_CA` should match it exactly.
+      expect(convertToStripeLocale('fr_CA')).toBe('fr-CA');
+    });
+  });
+
+  describe('base-language match', () => {
+    test.each([
+      ['de', 'de'],
+      ['fr', 'fr'],
+      ['es', 'es'],
+      ['zh', 'zh'],
+    ])('resolves bare language code %s to itself', (input, expected) => {
+      expect(convertToStripeLocale(input)).toBe(expected);
+    });
+  });
+
+  describe('region fallback to base language', () => {
+    test.each([
+      // `es-MX` and `fr-BE` fall back to `es` / `fr` even though `es-ES` / `fr-FR` exist:
+      // base-exact match runs before region-prefix scan to preserve Adyen-pattern parity.
+      ['es-MX', 'es'],
+      ['fr-BE', 'fr'],
+      ['pt-PT', 'pt'],
+      ['zh-CN', 'zh'],
+    ])('resolves %s to %s', (input, expected) => {
+      expect(convertToStripeLocale(input)).toBe(expected);
+    });
+  });
+
+  describe('unknown input', () => {
+    test('returns "auto" for unrecognized region code with no matching base', () => {
+      expect(convertToStripeLocale('xx-YY')).toBe('auto');
+    });
+
+    test('returns "auto" for arbitrary string', () => {
+      expect(convertToStripeLocale('klingon')).toBe('auto');
+    });
+  });
+
+  describe('falsy and whitespace input', () => {
+    test('returns "auto" for empty string', () => {
+      expect(convertToStripeLocale('')).toBe('auto');
+    });
+
+    test('returns "auto" for undefined', () => {
+      expect(convertToStripeLocale(undefined)).toBe('auto');
+    });
+
+    test('returns "auto" for whitespace-only string', () => {
+      expect(convertToStripeLocale('  ')).toBe('auto');
+    });
+  });
+});

--- a/enabler/test/express/stripe-express.spec.ts
+++ b/enabler/test/express/stripe-express.spec.ts
@@ -195,6 +195,7 @@ describe('StripeExpressComponent', () => {
         sdk: mockSdk,
         elements: null,
         captureMethod: 'automatic',
+        locale: 'fr-CA',
       });
       const expressOptions = createMockExpressOptions();
       const component = new StripeExpressComponent({ baseOptions, expressOptions });
@@ -207,6 +208,7 @@ describe('StripeExpressComponent', () => {
           amount: 2000,
           currency: 'eur',
           capture_method: 'automatic',
+          locale: 'fr-CA',
         }),
       );
       expect(mockCreatedElements.create).toHaveBeenCalledWith('expressCheckout', expect.objectContaining({

--- a/enabler/test/payment-enabler.spec.ts
+++ b/enabler/test/payment-enabler.spec.ts
@@ -171,4 +171,46 @@ describe('MockPaymentEnabler - Express Checkout', () => {
     // After mount, elements must have been created via sdk.elements() with initialAmount values
     expect((component as any).baseOptions?.elements).not.toBeNull();
   });
+
+  test('should forward converted locale to stripe.elements() in standard flow', async () => {
+    const enabler = new MockPaymentEnabler({
+      processorUrl: 'http://localhost:3000',
+      sessionId: 'test-session',
+      locale: 'es-MX',
+    } as any);
+
+    await enabler.createDropinBuilder('embedded' as any);
+
+    const mockStripe = await (loadStripe as jest.Mock).mock.results[0]?.value;
+    expect(mockStripe.elements).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: 'es' }),
+    );
+  });
+
+  test('should forward converted locale to sdk.elements() in Express without session', async () => {
+    const enabler = new MockPaymentEnabler({
+      processorUrl: 'http://localhost:3000',
+      sessionId: '',
+      locale: 'pt-BR',
+    } as any);
+
+    const builder = await enabler.createExpressBuilder('dropin');
+    const expressOptions = {
+      onPayButtonClick: jest.fn().mockResolvedValue({ sessionId: 'test-session-id' }),
+      onShippingAddressSelected: jest.fn().mockResolvedValue(undefined),
+      getShippingMethods: jest.fn().mockResolvedValue([]),
+      onShippingMethodSelected: jest.fn().mockResolvedValue(undefined),
+      onPaymentSubmit: jest.fn().mockResolvedValue(undefined),
+      onComplete: jest.fn(),
+      onError: jest.fn(),
+      initialAmount: { centAmount: 3500, currencyCode: 'EUR', fractionDigits: 2 },
+    };
+    const component = builder.build(expressOptions as any);
+    await component.mount('#express-checkout');
+
+    const mockStripe = await (loadStripe as jest.Mock).mock.results[0]?.value;
+    expect(mockStripe.elements).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: 'pt-BR' }),
+    );
+  });
 });

--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -1133,12 +1133,21 @@
       }
     },
     "node_modules/@fastify/merge-json-schemas": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
-      "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
-      "license": "MIT",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "dependencies": {
-        "fast-deep-equal": "^3.1.3"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/@fastify/proxy-addr": {
@@ -4632,6 +4641,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -5515,17 +5532,25 @@
       "license": "MIT"
     },
     "node_modules/fast-json-stringify": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.0.0.tgz",
-      "integrity": "sha512-FGMKZwniMTgZh7zQp9b6XnBVxUmKVahQLQeRQHqwYmPDqDhcEKZ3BaQsxelFFI5PY7nN71OEeiL47/zUWcYe1A==",
-      "license": "MIT",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
+      "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "dependencies": {
-        "@fastify/merge-json-schemas": "^0.1.1",
+        "@fastify/merge-json-schemas": "^0.2.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^2.3.0",
-        "json-schema-ref-resolver": "^1.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
         "rfdc": "^1.2.0"
       }
     },
@@ -5543,18 +5568,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
-      "license": "MIT"
-    },
-    "node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
-      "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
-      "license": "MIT"
     },
     "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -5579,10 +5592,19 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
-      "license": "MIT"
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fastify": {
       "version": "5.8.5",
@@ -8726,12 +8748,21 @@
       "license": "MIT"
     },
     "node_modules/json-schema-ref-resolver": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
-      "integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "dependencies": {
-        "fast-deep-equal": "^3.1.3"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/json-schema-traverse": {


### PR DESCRIPTION
Introduce `convertToStripeLocale` to map arbitrary BCP-47 locale strings (e.g. "es-MX", "fr_CA", "EN-gb") to valid `StripeElementLocale` values. Resolution order: explicit mapping → exact match → base-language fallback → region-prefix scan → "auto" (Stripe's native fallback for unrecognized input).

Wire the converted locale through both `createDropinBuilder` and `createExpressBuilder` flows in `MockPaymentEnabler` and into the `stripe.elements()` call in `StripeExpressComponent`. Also tighten the `BaseOptions.locale` type from `string` to `StripeElementLocale`.

Note: locale is intentionally omitted from `elements.update()` since Stripe ignores it there; it must be set at creation time.