### PR TITLE
feat(express): bind customer on _Setup path via x-express-customer-session header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,14 @@
 
 #Context documentation
 docs/context7-libraries
-context
 context7-config.json
 CLAUDE.md
 
 # Connect CLI generated files
 .connect
+
+# Test coverage output
+coverage/
+
+# Build output
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- **Express Checkout `_Setup` path — customer binding**: When Express Checkout is initialized with a CT session at render time (`_Setup` path), the enabler now sends `x-express-customer-session: true` on `GET /payments`. The processor uses this header to bind `customer` and `setup_future_usage` on the PaymentIntent, matching the Stripe Elements instance created with `customerOptions` and `setupFutureUsage`. The `_SetupExpress` (deferred) path is unaffected — PaymentIntents on that path remain one-shot with no customer binding.
 - Enhanced refund processing with support for multiple refunded events
 - New `processStripeEventRefunded` method in StripePaymentService for dedicated refund event handling
 - Improved refund data accuracy by retrieving latest refund information from Stripe API

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -1,0 +1,247 @@
+# Architecture — ct-connect-stripe-checkout
+
+Commercetools Connect connector that integrates Stripe Payment Element and Express Checkout into a CT-managed checkout flow. Handles payment creation, confirmation, capture, refunds, and webhook synchronization between Stripe and CT.
+
+## System Overview
+
+Two-tier architecture: a **processor** (Node.js backend) and an **enabler** (TypeScript frontend wrapper). They communicate via HTTP; the processor talks to both Stripe and CT APIs.
+
+```text
+Browser / Storefront
+  └── Enabler (Stripe.js SDK wrapper)
+        │  GET /config-element, /customer/session, /payments
+        │  POST /confirmPayments/:id
+        ▼
+    Processor (Fastify)
+        ├── Stripe API (Payment Intents, Customers, Refunds, Webhooks)
+        └── commercetools API (Payments, Carts, Customers, Custom Types)
+
+Stripe (async)
+  └── POST /stripe/webhooks → Processor → CT Payment updates
+```
+
+## Components
+
+| Component | Role | Entry point |
+| --- | --- | --- |
+| `processor/` | Backend — all Stripe and CT API calls | `processor/src/main.ts` |
+| `enabler/` | Frontend — mounts Stripe Elements, orchestrates payment submission | `enabler/src/main.ts` |
+
+### Processor internals
+
+| Layer | Path | Purpose |
+| --- | --- | --- |
+| Routes | `src/routes/stripe-payment.route.ts` | Frontend-facing payment endpoints + Stripe webhook dispatcher |
+| Routes | `src/routes/operation.route.ts` | CT Connect SDK endpoints (capture, cancel, refund, reverse) |
+| Service | `src/services/abstract-payment.service.ts` | Abstract base + `modifyPayment()` action dispatch |
+| Service | `src/services/stripe-payment.service.ts` | All Stripe business logic (PI, customer session, refunds, webhooks, multi-capture) |
+| Converter | `src/services/converters/stripeEventConverter.ts` | Maps Stripe events → CT transaction updates |
+| CT helpers | `src/services/commerce-tools/customerClient.ts`, `customTypeClient.ts`, `customTypeHelper.ts`, `productTypeClient.ts` | CT API helpers used by service and connectors |
+| Client | `src/clients/stripe.client.ts` | Stripe SDK factory + error wrapping |
+| Config | `src/config/config.ts` | Environment variable access |
+| Constants | `src/constants.ts` | Tax calculation custom field constants |
+| Custom types | `src/custom-types/custom-types.ts` | CT custom type and product type definitions |
+| Connectors | `src/connectors/actions.ts`, `post-deploy.ts`, `pre-undeploy.ts` | Deploy/undeploy lifecycle hooks |
+| Hooks | `src/libs/fastify/hooks/stripe-header-auth.hook.ts` | Pre-handler hook checking `stripe-signature` header presence (full HMAC verification happens inside the route handler via `stripe.webhooks.constructEvent()`) |
+
+### Enabler internals
+
+| Layer | Path | Purpose |
+| --- | --- | --- |
+| Interface | `src/payment-enabler/payment-enabler.ts` | Public contracts (no implementation) |
+| Implementation | `src/payment-enabler/payment-enabler-mock.ts` | SDK init, session setup, config fetch |
+| Drop-in | `src/dropin/dropin-embedded.ts` | Stripe Payment Element — submit flow |
+| Express | `src/express/dropin-express.ts` | Express Checkout Element — session and shipping callbacks |
+
+#### Dropin types
+
+| Dropin | Builder | Status |
+| --- | --- | --- |
+| `embedded` | `DropinEmbeddedBuilder` | Active |
+| `express` | `StripeExpressBuilder` | Active |
+| `hpp` | _(not exported from main.ts)_ | Not supported |
+
+#### Initialization flows
+
+**Session flow** (`_Setup`) — used by embedded dropin and express when a `sessionId` is available:
+
+```text
+GET /config-element/payment  ─┐  (parallel)
+GET /operations/config       ─┘
+GET /customer/session
+loadStripe(publishableKey)
+stripe.elements({ mode:'payment', amount, currency, customerOptions, appearance, capture_method })
+elements.create('payment', elementOptions)
+```
+
+**Express-without-session flow** (`_SetupExpress`) — used when rendering Express buttons before the user has a session (no `sessionId` on `EnablerOptions`):
+
+```text
+POST /express-config   (CORS only — no session header)
+loadStripe(publishableKey)
+← Elements creation deferred to StripeExpressComponent.init() when real amount is available
+```
+
+#### Express Checkout event flow
+
+| Stripe event | Handler | What it does |
+| --- | --- | --- |
+| `click` | `kickOffSessionInitFromClick()` | Resolves immediately with initial line items; starts async `onPayButtonClick()` session refresh in background |
+| `confirm` | `handlePaymentConfirm()` | Submit Elements → optional `onPaymentSubmit` → `GET /payments` → `confirmPayment` → `POST /confirmPayments/:id` → `onComplete` |
+| `cancel` | `handleCancel()` | Resets session state; calls `onError` with `error.name = 'CANCEL'` |
+| `shippingaddresschange` | `handleShippingAddressChange()` | Sets CT shipping address → loads shipping methods → applies first rate → fetches totals → updates Elements amount |
+| `shippingratechange` | `handleShippingRateChange()` | Sets CT shipping method → fetches totals → updates Elements amount |
+
+**Session generation guard:** `sessionInitGeneration` counter prevents stale async completions from a previous `click` from overwriting a newer session.
+
+#### Processor API calls from the enabler
+
+| Method | Endpoint | Header | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/config-element/payment` | `x-session-id` | Appearance, layout, captureMethod, setupFutureUsage, cartInfo |
+| `GET` | `/operations/config` | `x-session-id` | publishableKey, environment |
+| `GET` | `/customer/session` | `x-session-id` | stripeCustomerId, ephemeralKey, sessionId (204 = guest) |
+| `POST` | `/express-config` | none (CORS) | publishableKey, captureMethod, appearance, expressElementOptions |
+| `GET` | `/payments` | `x-session-id`, `x-express-checkout: true` (express only) | Creates PI + CT Payment; returns clientSecret |
+| `POST` | `/confirmPayments/:id` | `x-session-id` | 4-point validation; updates CT to AUTHORIZED |
+| `GET` | `/express-payment-data` | `x-session-id` | Cart totals and line items after shipping changes |
+
+## API Endpoints
+
+### Frontend-facing (`stripe-payment.route.ts`)
+
+| Endpoint | Auth | Purpose |
+| --- | --- | --- |
+| `GET /payments` | SessionHeader | Creates Stripe PaymentIntent + CT Payment. Accepts header `x-express-checkout: 'true'` or `'1'` (string, case-sensitive) to skip shipping params on the PI. |
+| `POST /confirmPayments/:id` | SessionHeader | Validates PI against CT payment (4-point check) and marks CT payment as AUTHORIZED. |
+| `GET /customer/session` | SessionHeader | Returns Stripe customer ID, ephemeral key, and customer session ID for saved payment methods. Returns 204 if the cart has no `customerId` (guest checkout) or the customer cannot be found. |
+| `GET /express-payment-data` | SessionHeader | Returns cart totals and line items for Express Checkout display. |
+| `GET /config-element/:paymentComponent` | SessionHeader | Returns appearance, layout, capture method, and billing address config for the element. |
+| `POST /express-config` | CORS | Returns publishable key and config for Express buttons. No session required — called before user interaction. |
+| `GET /applePayConfig` | None | Returns Apple Pay domain association file. Intentionally public — required by Apple's domain verification spec. |
+| `POST /stripe/webhooks` | Stripe Signature | Receives and processes Stripe events. Pre-handler hook checks `stripe-signature` header presence; full signature verification (`stripe.webhooks.constructEvent`) happens inside the handler. Event processing runs synchronously and the handler returns 200 after processing completes. |
+
+### CT Connect SDK (`operation.route.ts`)
+
+| Endpoint | Auth | Purpose |
+| --- | --- | --- |
+| `GET /config` | SessionHeader | Returns publishable key, capture method, appearance. |
+| `GET /status` | JWT | Health check — validates CT permissions + Stripe connectivity. |
+| `GET /payment-components` | JWT | Returns supported components under the `dropins` key: `dropin` (embedded), `express` (dropin). |
+| `POST /payment-intents/:id` | OAuth2 | Modifies a payment: capture, cancel, refund, or reverse. |
+
+## Integration Boundaries
+
+### Stripe API calls (by operation)
+
+| Operation | Stripe methods |
+| --- | --- |
+| Create payment | `paymentIntents.create()`, then `paymentIntents.update()` (separate metadata patch for `ct_payment_id`) |
+| Confirm payment | `paymentIntents.retrieve()` |
+| Capture | `paymentIntents.capture()` |
+| Cancel | `paymentIntents.cancel()` |
+| Refund | `refunds.create()`, `refunds.list()` |
+| Customer | `customers.retrieve()`, `customers.search()`, `customers.create()` |
+| Saved methods | `paymentMethods.retrieve()`, `paymentMethods.list()` |
+| Session | `customerSessions.create()`, `ephemeralKeys.create()` |
+| Webhooks | `webhooks.constructEvent()` |
+| Multi-capture | `balanceTransactions.list()` — called in `processStripeEvent()` only when: `charge.updated` event, `capture_method === 'manual'`, `payment_method_options.card.request_multicapture === 'if_available'`, and `latest_charge` is a non-empty string. |
+
+### commercetools API calls (by operation)
+
+| Operation | CT methods |
+| --- | --- |
+| Create payment | `ctCartService.getCart()`, `ctPaymentService.createPayment()`, `ctCartService.addPayment()` |
+| Confirm payment | `ctPaymentService.getPayment()`, `ctPaymentService.updatePayment()` |
+| Webhooks | `ctPaymentService.updatePayment()` |
+| Customer session | `paymentSDK.ctAPI.client.customers()`, `updateCustomerById()` |
+| Saved methods | `ctPaymentMethodService.getByTokenValue()`, `ctPaymentMethodService.save()` |
+
+## CT Data Model
+
+### CT Payment object
+
+The CT Payment is the source of truth for transaction state. Stripe is the source of truth for money movement.
+
+| Field | Value |
+| --- | --- |
+| `paymentMethodInfo.paymentInterface` | `checkout-stripe` (configurable via `PAYMENT_INTERFACE`) |
+| `paymentMethodInfo.method` | Stripe payment method type |
+| `paymentMethodInfo.token.value` | Stripe `PaymentMethod` ID (set by `updatePaymentWithToken` after a saved-card webhook) |
+| Tax calculations | Stored on the **cart** custom field `connectorStripeTax_calculationReferences` (see `processor/src/constants.ts` → `CT_CUSTOM_FIELD_TAX_CALCULATIONS`). Forwarded to the PI via `hooks.inputs.tax.calculation` only when **exactly one** reference is present; zero or multiple references are silently ignored. |
+
+### CT Custom Types and Product Types
+
+**Installed by `post-deploy`:**
+
+| Key (env override) | Resource | Purpose |
+| --- | --- | --- |
+| `payment-connector-stripe-customer-id` (`CT_CUSTOM_TYPE_STRIPE_CUSTOMER_KEY`) | customer | Stores Stripe customer ID in field `stripeConnector_stripeCustomerId` |
+| `payment-launchpad-purchase-order` (`CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY`) | payment | Existence check only during post-deploy; fields `launchpadPurchaseOrderNumber`, `launchpadPurchaseOrderInvoiceMemo` must be pre-created by merchant |
+
+**Defined but NOT installed by `post-deploy` (subscription-related; not used by this connector):**
+
+| Key (env override) | Resource | Purpose |
+| --- | --- | --- |
+| `payment-connector-subscription-line-item-type` (`CT_CUSTOM_TYPE_SUBSCRIPTION_LINE_ITEM_KEY`) | line-item | Fields: `stripeConnector_productSubscriptionId`, `stripeConnector_stripeSubscriptionId`, `stripeConnector_stripeSubscriptionError` |
+| `payment-connector-subscription-information` (`CT_PRODUCT_TYPE_SUBSCRIPTION_KEY`) | product-type | 15 subscription attributes (see `ct-connect-stripe-composable` for full list) |
+
+### Transaction types used
+
+| CT Transaction Type | Meaning |
+| --- | --- |
+| `AUTHORIZATION` | PI created (requires_capture) or succeeded |
+| `CHARGE` | Payment captured or succeeded (automatic) |
+| `CANCEL_AUTHORIZATION` | PI canceled |
+| `REFUND` | Charge refunded |
+| `CHARGE_BACK` | Chargeback initiated (no handler — manual only) |
+
+## Webhook Event Subscriptions
+
+The following events are registered on the Stripe webhook endpoint during `post-deploy` (hardcoded in `src/connectors/actions.ts`):
+
+- `charge.succeeded`
+- `charge.updated` (required for multi-capture delta tracking)
+- `charge.refunded`
+- `payment_intent.succeeded`
+- `payment_intent.canceled`
+- `payment_intent.payment_failed`
+- `payment_intent.requires_action` (subscribed but has no handler — events are received and silently dropped)
+
+## Key Configuration
+
+| Variable | Required | Effect |
+| --- | --- | --- |
+| `STRIPE_SECRET_KEY` | Yes | Stripe API key. Defaults to `'stripeSecretKey'` — must be overridden. |
+| `STRIPE_PUBLISHABLE_KEY` | Yes | Sent to browser for Stripe.js initialization. Defaults to `''`. |
+| `STRIPE_WEBHOOK_SIGNING_SECRET` | Yes | Webhook HMAC secret. Defaults to `''` — all webhooks rejected if not set. |
+| `STRIPE_CAPTURE_METHOD` | No | `automatic`, `automatic_async`, or `manual`. Default: `automatic`. |
+| `STRIPE_ENABLE_MULTI_OPERATIONS` | No | Enables multicapture + multi-refund via `charge.updated`. Default: `false`. |
+| `STRIPE_PAYMENT_INTENT_SETUP_FUTURE_USAGE` | No | Sets reuse intent on PaymentIntent. Values `''`, `'none'`, `'null'`, `'undefined'` treated as absent. |
+| `STRIPE_SAVED_PAYMENT_METHODS_CONFIG` | No | JSON config for Payment Element saved methods feature. |
+| `STRIPE_COLLECT_BILLING_ADDRESS` | No | `auto`, `never`, or `if_required`. Default: `auto`. |
+| `STRIPE_APPLE_PAY_WELL_KNOWN` | No | Raw string returned by `/applePayConfig` for Apple Pay domain association. |
+| `ALLOWED_ORIGINS` | Yes | Comma-separated CORS whitelist for `/express-config`. Must include the storefront origin. |
+| `MERCHANT_RETURN_URL` | Yes | Return URL after 3DS or redirect-based payment methods. |
+| `PAYMENT_INTERFACE` | No | Value written to `paymentMethodInfo.paymentInterface`. Default: `checkout-stripe`. |
+| `CTP_PROJECT_KEY` | Yes | CT project key. Defaults to `'payment-integration'`. |
+| `CTP_CLIENT_ID` | Yes | CT OAuth2 client ID. Defaults to `'xxx'`. |
+| `CTP_CLIENT_SECRET` | Yes | CT OAuth2 client secret. Defaults to `'xxx'`. |
+| `CT_CUSTOM_TYPE_STRIPE_CUSTOMER_KEY` | No | Custom type key for Stripe customer ID. Default: `payment-connector-stripe-customer-id`. |
+| `CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY` | No | Custom type key for Launchpad PO. Default: `payment-launchpad-purchase-order`. |
+| `CONNECT_SERVICE_URL` | Yes (post-deploy) | CT Connect service URL; injected by CT Connect. |
+| `STRIPE_WEBHOOK_ID` | Yes (post-deploy) | Stripe webhook endpoint ID; injected by CT Connect. |
+
+## Out of Scope
+
+| Feature | Status |
+| --- | --- |
+| Subscriptions / recurring billing | Use `ct-connect-stripe-composable` |
+| SetupIntent (save now, charge later) | CT custom types defined but not installed or used |
+| Dispute / chargeback automation | `charge.dispute.*` not registered; requires manual process |
+| CT coupon / discount → Stripe sync | Not implemented |
+| Stripe Connect (marketplace, split payments) | Not in this hub |
+| Stripe Terminal (in-person) | Not implemented |
+| Stripe Link | Surfaced by Payment Element only; no dedicated flow |
+| Hosted Payment Page (HPP) | Defined in code but not exported or supported |
+| Mixed carts (subscription + one-time) | Requires `ct-connect-stripe-composable` |

--- a/context/adopter-guide.md
+++ b/context/adopter-guide.md
@@ -1,0 +1,144 @@
+# ct-connect-stripe-checkout — Adopter Guide
+
+> Who this is for: teams deploying ct-connect-stripe-checkout for one-time payments.
+> For connector internals see `context/ARCHITECTURE.md`.
+> Not sure which connector you need? See `ct-stripe/context/adopter-guide.md`.
+
+---
+
+## 1. Prerequisites
+
+Before deploying, confirm you have:
+
+**commercetools:**
+- CT project with API client credentials (client ID, client secret, project key)
+- API client scopes: `manage_payments`, `manage_orders`, `manage_customers`, `manage_types`, `manage_products`, `view_products`
+
+**Stripe:**
+- Stripe account (test or live)
+- Stripe secret key (`sk_test_...` or `sk_live_...`)
+- Stripe publishable key (`pk_test_...` or `pk_live_...`)
+- Stripe webhook signing secret — created automatically by CT Connect post-deploy; do not set manually before first deploy
+
+> If you plan to use Multicapture (partial captures and multi-refund), contact Stripe to enable `STRIPE_ENABLE_MULTI_OPERATIONS` on your account before going live.
+
+---
+
+## 2. What This Connector Deploys
+
+Post-deploy creates these resources in your environment automatically:
+
+| Component | Type | What it does |
+| --- | --- | --- |
+| Stripe webhook endpoint | Stripe | Receives `payment_intent.succeeded`, `payment_intent.payment_failed`, `charge.succeeded`, `charge.refunded` — delivers to the processor's `/stripe/webhooks` |
+| `payment-connector-stripe-customer-id` | CT Custom Type (customer) | Stores `stripeConnector_stripeCustomerId` — links a CT customer to their Stripe Customer |
+
+> **Not created by the connector:** `payment-launchpad-purchase-order` — this CT custom type is required for B2B purchase orders but must be created by your team before deploying. See Section 5.
+
+---
+
+## 3. Installation
+
+### Step 1 — Deploy via CT Connect
+
+Deploy `ct-connect-stripe-checkout` through the CT Connect marketplace. The post-deploy script runs automatically and creates the resources listed above.
+
+### Step 2 — Configure environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `STRIPE_SECRET_KEY` | **Yes** | Stripe secret API key |
+| `STRIPE_PUBLISHABLE_KEY` | **Yes** | Stripe publishable key — sent to the browser enabler |
+| `STRIPE_WEBHOOK_SIGNING_SECRET` | **Yes** | Copy from Stripe Dashboard after first deploy — do not guess this value |
+| `MERCHANT_RETURN_URL` | **Yes** | Full URL of your storefront's payment return page (used after 3DS redirect) |
+| `ALLOWED_ORIGINS` | **Yes** | Comma-separated storefront origins allowed to call `/express-config` (e.g. `https://your-store.com`). Without this, Express Checkout returns 403. |
+| `CTP_PROJECT_KEY` | **Yes** | CT project key |
+| `CTP_CLIENT_ID` | **Yes** | CT API client ID |
+| `CTP_CLIENT_SECRET` | **Yes** | CT API client secret |
+| `STRIPE_CAPTURE_METHOD` | No | `automatic` (default), `automatic_async`, or `manual` |
+| `STRIPE_ENABLE_MULTI_OPERATIONS` | No | `true` to enable partial captures and multi-refund (Stripe account feature required) |
+| `STRIPE_COLLECT_BILLING_ADDRESS` | No | `auto` (default), `never`, or `if_required` |
+
+> **After first deploy:** go to Stripe Dashboard → Developers → Webhooks → your endpoint → Signing secret. Copy it into `STRIPE_WEBHOOK_SIGNING_SECRET` and redeploy. Payments will succeed but CT will not update until this is set.
+
+### Step 3 — Verify post-deploy resources
+
+In CT Merchant Center → Settings → Developer → API → Custom Types:
+- `payment-connector-stripe-customer-id` exists with field `stripeConnector_stripeCustomerId`
+
+In Stripe Dashboard → Developers → Webhooks:
+- A webhook endpoint pointing at `https://your-processor/stripe/webhooks` exists
+
+---
+
+## 4. Integrating the Enabler
+
+The enabler is a JavaScript bundle that wraps Stripe Payment Element and Express Checkout Element. Mount it in your checkout page.
+
+### Standard embedded payment (Payment Element)
+
+```typescript
+import { Enabler } from '@your-scope/ct-connect-stripe-checkout-enabler';
+
+const enabler = new Enabler({
+  processorUrl: 'https://your-processor.ct-connect.example.com',
+  sessionId: ctSessionId,   // from CT session API
+  locale: 'en-US',
+});
+
+const dropin = await enabler.createDropin({ paymentElementType: 'paymentElement' });
+await dropin.mount('#payment-element');
+```
+
+### Express Checkout (Apple Pay / Google Pay)
+
+Requires `ALLOWED_ORIGINS` to be set to your storefront's origin.
+
+```typescript
+const dropin = await enabler.createDropin({ paymentElementType: 'expressCheckout' });
+await dropin.mount('#express-checkout-element');
+```
+
+### B2B Launchpad purchase orders
+
+The `payment-launchpad-purchase-order` CT custom type must be created by your team **before deploying**. The connector checks for its existence at startup but does not create it.
+
+```typescript
+// Create via CT API before first deploy:
+{
+  key: 'payment-launchpad-purchase-order',
+  resourceTypeIds: ['payment'],
+  fields: [
+    { name: 'launchpadPurchaseOrderNumber', type: { name: 'String' }, required: false },
+    { name: 'launchpadPurchaseOrderInvoiceMemo', type: { name: 'String' }, required: false },
+  ]
+}
+```
+
+---
+
+## 5. Verification Checklist
+
+Before go-live:
+
+- [ ] `GET /operations/config` returns a response including `publishableKey`
+- [ ] Complete a test payment using Stripe test card `4242 4242 4242 4242` — CT payment should have a `CHARGE:SUCCESS` transaction
+- [ ] Check Stripe Dashboard — a PaymentIntent with `ct_payment_id` in metadata should appear
+- [ ] Trigger a refund via `POST /payment-intents/{id}` with `action: refund` — CT payment should gain a `REFUND` transaction
+- [ ] Stripe Dashboard → Webhooks → Recent deliveries — all events should show HTTP 200
+- [ ] Express Checkout buttons appear on the page (if using `expressCheckout` drop-in)
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Stripe webhook events show HTTP 400 | `STRIPE_WEBHOOK_SIGNING_SECRET` wrong or not set | Copy signing secret from Stripe Dashboard webhook endpoint; redeploy |
+| Payment succeeds in Stripe but CT payment not updated | Webhook failing — signing secret mismatch | Same as above; also check processor logs for 400s |
+| Express Checkout buttons not appearing | `ALLOWED_ORIGINS` not set — `/express-config` returns 403 | Set `ALLOWED_ORIGINS` to your storefront origin |
+| CT payment stuck in `AUTHORIZATION:SUCCESS`, never moves to `CHARGE` | `payment_intent.succeeded` webhook not processed | Verify webhook health in Stripe Dashboard; check processor logs |
+| Refund processed in Stripe but CT payment has no `REFUND` transaction | `charge.refunded` webhook failed | Check Stripe Dashboard → Webhooks → logs for that event |
+| Double charge after network retry | Connector does not use stable idempotency keys on capture | Check Stripe Dashboard; manually refund duplicate; disable infrastructure-level auto-retry |
+| All payments fail at startup with auth errors | Placeholder credentials in env vars (`'stripeSecretKey'`, `'xxx'`) | Set all required env vars with real values |
+| `payment-launchpad-purchase-order` not found | Custom type not created before deploy | Create the custom type manually (see Section 4) |

--- a/context/business-rules/customer-session.md
+++ b/context/business-rules/customer-session.md
@@ -1,0 +1,101 @@
+# Business Rule: Customer Session & Saved Payment Methods
+
+## Overview
+
+To support saved payment methods, the connector manages a bidirectional mapping between CT customers and Stripe customers. The CT customer record is the source of truth for the customer identity; Stripe is the source of truth for the payment methods.
+
+---
+
+## Rule 1: Stripe customer ID is resolved with a 3-step fallback
+
+**What:** When a customer session is requested, the service resolves the Stripe customer in this order:
+1. Read saved ID from CT customer custom field (`CT_CUSTOM_TYPE_STRIPE_CUSTOMER_KEY`)
+2. If found, validate it still exists in Stripe (`customers.retrieve`), is not deleted, and that `metadata.ct_customer_id` matches the CT customer ID
+3. If not found or invalid, search Stripe by `metadata.ct_customer_id` using `customers.search({ query: "metadata['ct_customer_id']:'<id>'" })` — the CT customer ID must be a valid UUID or the search is skipped
+4. If still not found, create a new Stripe customer with email, name, phone, and address; `ct_customer_id` is stored in Stripe metadata. Email priority: `cart.customerEmail` → `customer.email` → `cart.shippingAddress?.email` → empty string
+
+**Why:** CT customers can exist before any Stripe interaction. Stripe customers may be deleted externally. The search-by-metadata fallback recovers from edge cases where the custom field was lost. UUID validation before search prevents Stripe from receiving malformed queries.
+
+**Invariant:** Never create a duplicate Stripe customer for the same CT customer. Always exhaust the lookup chain before creating.
+
+**Implementation:** `stripe-payment.service.ts` → `retrieveOrCreateStripeCustomerId()`, `validateStripeCustomerId()`, `findStripeCustomer()`, `createStripeCustomer()`
+
+**What breaks if violated:** Same CT customer accumulates multiple Stripe customer records, causing split payment method history and potential billing inconsistencies. Non-UUID CT customer IDs will silently skip the search and always create a new Stripe customer.
+
+---
+
+## Rule 2: Stripe customer ID is saved back to CT immediately after creation
+
+**What:** After creating a new Stripe customer, the ID is saved to the CT customer's custom field via `saveStripeCustomerId()`.
+
+**Why:** Without this, every subsequent session request would fail the lookup and create a new Stripe customer (violating Rule 1).
+
+**Invariant:** `retrieveOrCreateStripeCustomerId()` always ends with a valid, persisted Stripe customer ID in CT.
+
+**Implementation:** `stripe-payment.service.ts` → `saveStripeCustomerId()`
+
+**What breaks if violated:** Duplicate Stripe customers are created on every session request for the same CT customer.
+
+---
+
+## Rule 3: Recurring carts always force `off_session` and `payment_method_save`
+
+**What:** If the cart is identified as a recurring cart, `setup_future_usage` is forced to `off_session` regardless of the `STRIPE_PAYMENT_INTENT_SETUP_FUTURE_USAGE` config, and the customer session enables `payment_method_save`.
+
+**Why:** Recurring carts (subscriptions) require a saved payment method that can be charged without the customer being present. This is non-negotiable for subscription billing.
+
+**Invariant:** `off_session` cannot be overridden by config for recurring carts. The config override only applies to non-recurring carts.
+
+**Implementation:** `stripe-payment.service.ts` → `getPaymentIntentSetupFutureUsage()`, `createSession()`
+
+**What breaks if violated:** Subscriptions fail when attempting to charge the saved payment method, because Stripe was not told the method would be used off-session.
+
+---
+
+## Rule 4: Customer session requires a logged-in customer (cart.customerId)
+
+**What:** `GET /customer/session` only proceeds if `cart.customerId` is present. If the cart has no customer (guest checkout), the session is skipped.
+
+**Why:** Saved payment methods are tied to a customer identity. Guest checkouts have no identity to associate methods with.
+
+**Invariant:** Never create a Stripe customer or session for a guest cart. Return without customer data; the Payment Element will operate without saved methods.
+
+**Implementation:** `stripe-payment.service.ts` → `getCustomerSession()` — early return if no `customerId`.
+
+**What breaks if violated:** Stripe customers are created for anonymous sessions, polluting the Stripe customer list with records that can never be reused.
+
+---
+
+## Rule 5: `setup_future_usage` follows a 3-tier priority system
+
+**What:** `getPaymentIntentSetupFutureUsage()` resolves the value in this order:
+
+1. **Recurring cart (highest priority):** if `isRecurringCart(cart)` returns true, forces `off_session` regardless of any config value
+2. **Config override:** `STRIPE_PAYMENT_INTENT_SETUP_FUTURE_USAGE` env var, if set to a non-empty, non-null, non-`'none'` value
+3. **Default:** the connector's default config value
+
+String normalization: values of `''`, `'none'`, `'null'`, and `'undefined'` are treated as absent (no `setup_future_usage` set on the PI).
+
+**Why:** Recurring carts must always produce `off_session` — this cannot be overridden by operators. The config override allows merchants to set a default for non-recurring flows. Normalization prevents silent breakage from misconfigured env vars.
+
+**Invariant:** `off_session` for recurring carts is unconditional. The config override only applies when the cart is not recurring.
+
+**Implementation:** `stripe-payment.service.ts` → `getPaymentIntentSetupFutureUsage()`
+
+**What breaks if violated:** Subscriptions fail when attempting to charge the saved payment method off-session. Stripe rejects the charge with "This payment method was not set up for off-session use."
+
+**Note — Express Checkout scope:** This rule applies to all checkout paths, including Express Checkout when a customer is known (`expressWithCustomer = true`). The `_SetupExpress` deferred path (no session at render time, no customer) produces no `setup_future_usage` regardless of this rule, because there is no customer to bind. See `payment-lifecycle.md` Rule 7 and ADR-005.
+
+---
+
+## Rule 6: Ephemeral keys are scoped to the Stripe API version in config
+
+**What:** `ephemeralKeys.create()` uses the `STRIPE_API_VERSION` from config.
+
+**Why:** Ephemeral keys are version-locked. A key created with one API version cannot be used with a different version in the mobile SDK.
+
+**Invariant:** The API version used for ephemeral keys must match the version used by the mobile SDK client.
+
+**Implementation:** `stripe-payment.service.ts` → `createEphemeralKey()`
+
+**What breaks if violated:** Mobile SDK fails to use the ephemeral key, blocking saved payment method display on mobile.

--- a/context/business-rules/multi-operations.md
+++ b/context/business-rules/multi-operations.md
@@ -1,0 +1,79 @@
+# Business Rule: Multi-Capture & Multi-Refund
+
+## Overview
+
+Multi-operations (partial captures and multiple refunds) are an opt-in feature controlled by `STRIPE_ENABLE_MULTI_OPERATIONS`. When disabled, the connector assumes single capture and single refund per payment. When enabled, it supports incremental captures and multiple partial refunds.
+
+---
+
+## Rule 1: Partial captures require the feature flag and pass a cart total comparison
+
+**What:** `capturePayment()` determines whether a capture is partial by comparing `stripePaymentIntent.amount_received + amountToBeCaptured < cartTotalAmount`. If the result is partial:
+
+- `STRIPE_ENABLE_MULTI_OPERATIONS=false` → logs error and throws; operation rejected
+- `STRIPE_ENABLE_MULTI_OPERATIONS=true` → proceeds with `final_capture: false`
+
+If `amountPlanned.centAmount` is missing from the CT payment, an error is thrown before any Stripe call (guard against misconfigured CT data).
+
+**Why:** Partial capture is a deliberate merchant choice, not a default behavior. Accidental partial captures leave money on the table and confuse order reconciliation.
+
+**Invariant:** `STRIPE_ENABLE_MULTI_OPERATIONS=false` means only full captures are allowed. Any request with a partial amount must be rejected.
+
+**Implementation:** `stripe-payment.service.ts` → `capturePayment()` — early guard on `stripeEnableMultiOperations`.
+
+**What breaks if violated:** Partial amounts are captured without the merchant's explicit intention to use multi-capture. The remaining authorized amount is released by Stripe after its authorization window expires.
+
+---
+
+## Rule 2: Non-final captures use `final_capture: false`
+
+**What:** When capturing an amount less than the full authorized amount, `final_capture: false` is passed to Stripe. This signals that more captures will follow and keeps the authorization open.
+
+**Why:** Without `final_capture: false`, Stripe treats every capture as the last one and releases any remaining authorized amount.
+
+**Invariant:** Any partial capture must set `final_capture: false`. Only the final capture in a sequence can omit this flag (or pass `true`).
+
+**Implementation:** `stripe-payment.service.ts` → `capturePayment()` — `final_capture: false` when partial.
+
+**What breaks if violated:** The first partial capture closes the authorization. Subsequent captures fail because there is nothing left to capture.
+
+---
+
+## Rule 3: Multi-capture webhook uses the delta from `previous_attributes`, not the cumulative event amount
+
+**What:** When `charge.updated` arrives (multi-capture event) and `STRIPE_ENABLE_MULTI_OPERATIONS=true`, `processStripeEventMultipleCaptured()`:
+
+1. Skips processing if `charge.captured === true` (already fully captured) or if `charge.amount_captured` did not increase vs `previous_attributes.amount_captured` — silent early return, CT not updated.
+2. Computes delta: `charge.amount_captured - previous_attributes.amount_captured`. That delta becomes the CT CHARGE transaction amount.
+3. Records `charge.balance_transaction` as `interactionId` and `pspReference`.
+
+There is also a separate code path inside `processStripeEvent()` that calls `balanceTransactions.list({ source: latest_charge, limit: 10 })` when all three conditions hold: `capture_method === 'manual'`, `payment_method_options.card.request_multicapture === 'if_available'`, and `latest_charge` is a non-empty string. If the result has more than one balance transaction, `interactionId` and `amount` are overridden from `balanceTransactions.data[0]`.
+
+**Why:** CT needs individual transaction records, not cumulative totals. If `amount_captured` is used directly, each new capture overstates the total by including previous captures.
+
+**Invariant:** For multi-capture, always compute the delta. Store that delta as the CT CHARGE transaction amount.
+
+**Implementation:**
+
+- `processor/src/services/stripe-payment.service.ts` → `processStripeEventMultipleCaptured()` (delta from `previous_attributes`)
+- `processor/src/services/stripe-payment.service.ts` → `processStripeEvent()` (balance-transactions branch for multicapture-flagged PIs)
+
+**What breaks if violated:** CT shows inflated capture amounts. The total captured in CT far exceeds the actual charge, causing reconciliation failures.
+
+---
+
+## Rule 4: Multi-refund tracking warns on the second refund and per-refund amounts come from the webhook
+
+**What:** When `refundPayment()` runs, it calls `ctPaymentService.hasTransactionInState({ payment, transactionType: 'Refund', states: ['Success'] })` against the **CT** payment (not Stripe's `refunds.list`). If a successful refund already exists **and** `STRIPE_ENABLE_MULTI_OPERATIONS` is **disabled**, it logs a warning and continues. Per-refund CT amounts come from the asynchronous `charge.refunded` webhook handled by `processStripeEventRefunded()`, which calls `stripe.refunds.list({ charge, created: { gte: charge.created }, limit: 2 })` and uses the most recent refund object.
+
+**Why:** Each refund in a multi-refund sequence must be independently tracked. The warning surfaces unexpected multi-refund scenarios when the merchant has not enabled multi-operations.
+
+**Invariant:** When `STRIPE_ENABLE_MULTI_OPERATIONS=true`, each refund is a distinct Stripe refund object with its own ID, and the webhook handler creates a separate REFUND transaction per event using the per-refund amount (not the cumulative `amount_refunded`).
+
+**Implementation:**
+
+- `processor/src/services/stripe-payment.service.ts` → `refundPayment()` (CT-side detection + warning)
+- `processor/src/services/stripe-payment.service.ts` → `processStripeEventRefunded()` (per-refund amount via `stripe.refunds.list`)
+- Dispatcher: `processor/src/routes/stripe-payment.route.ts` selects `processStripeEventRefunded` vs `processStripeEvent` based on `stripeEnableMultiOperations`.
+
+**What breaks if violated:** Without individual refund tracking, the total refunded in CT is incorrect when multiple partial refunds exist.

--- a/context/business-rules/payment-lifecycle.md
+++ b/context/business-rules/payment-lifecycle.md
@@ -1,0 +1,118 @@
+# Business Rule: Payment Lifecycle
+
+## Overview
+
+A payment in this connector always involves two parallel objects: a **Stripe PaymentIntent** and a **CT Payment**. They must stay in sync. CT is the source of truth for transaction state; Stripe is the source of truth for money movement.
+
+---
+
+## Rule 1: PaymentIntent and CT Payment are created together atomically
+
+**What:** `GET /payments` creates both a Stripe PaymentIntent and a CT Payment in the same request, then associates the CT Payment to the cart.
+
+**Why:** The cart needs a CT Payment reference before the user can confirm. If only Stripe PI is created, CT has no record of the pending payment.
+
+**Invariant:** A Stripe PaymentIntent must always have a corresponding CT Payment. Never create one without the other.
+
+**Implementation:** `stripe-payment.service.ts` → `createPaymentIntentStripe()`
+
+**What breaks if violated:** CT has no transaction to update when the webhook arrives. The payment is lost from CT's perspective even if Stripe charged the customer.
+
+---
+
+## Rule 2: PaymentIntent must pass 4-point validation before CT is updated to AUTHORIZED
+
+**What:** After Stripe confirms a payment, the backend re-retrieves the PI from Stripe and validates:
+1. PI exists and was retrieved successfully
+2. PI status is `succeeded` or `requires_capture`
+3. `PI.metadata.ct_payment_id` matches the CT payment ID in the request
+4. `PI.amount` and `PI.currency` match the CT payment values
+
+**Why:** Prevents replay attacks and accidental cross-payment contamination. A client could pass any PI ID to `/confirmPayments/:id`.
+
+**Invariant:** All 4 checks must pass. Failure on any one must reject the confirmation and leave CT in the previous state.
+
+**Implementation:** `stripe-payment.service.ts` → `updatePaymentIntentStripeSuccessful()`
+
+**What breaks if violated:** A malicious client could confirm a different customer's payment against this cart, or confirm a failed/canceled PI as successful.
+
+---
+
+## Rule 3: Capture method is set at PI creation and cannot change
+
+**What:** `STRIPE_CAPTURE_METHOD` (`automatic`, `automatic_async`, `manual`) is passed to Stripe at PI creation. Manual capture requires an explicit `capturePayment` call later.
+
+**Why:** Stripe does not allow changing capture method after PI creation. The decision is permanent for that transaction.
+
+**Invariant:** Never attempt to capture a PI created with `automatic` capture — it was already charged at confirmation.
+
+**Implementation:** `config.ts` → `STRIPE_CAPTURE_METHOD`, `stripe-payment.service.ts` → `buildPaymentIntentCreateParams()`
+
+**What breaks if violated:** Capturing an `automatic` PI returns a Stripe error. The CT Payment ends up in an inconsistent state if the error is not handled correctly.
+
+---
+
+## Rule 4: CT Payment version must be tracked for optimistic locking
+
+**What:** CT uses optimistic locking on Payment updates. The version number must be current when sending update actions.
+
+**Why:** Concurrent webhook events or multiple captures could collide on the same CT Payment. Stale version = rejected update.
+
+**Invariant:** Always retrieve the latest CT Payment version before any update. Never cache the version across requests.
+
+**Implementation:** `ctPaymentService.updatePayment()` and `ctPaymentService.getPayment()` are used together by call sites in `processor/src/services/stripe-payment.service.ts` (e.g. `updatePaymentIntentStripeSuccessful`, `processStripeEvent`, `processStripeEventRefunded`, `processStripeEventMultipleCaptured`).
+
+**Note — limitation:** The Connect Payments SDK does **not** automatically retry on `409 ConcurrentModification` (see `context/reference/ct-connect-payments-sdk.md`). On a version conflict the call throws and the connector currently logs the error and continues; there is no retry loop. If concurrent webhooks for the same CT payment become a real concern, retry-with-fresh-version logic needs to be added at each `updatePayment` call site.
+
+**What breaks if violated:** CT returns a `409 ConcurrentModification` error. The transaction update is lost and CT state diverges from Stripe.
+
+---
+
+## Rule 5: Express Checkout skips shipping on PaymentIntent
+
+**What:** When `x-express-checkout: true` header is present on `GET /payments`, the PI is created without shipping parameters. Shipping is handled by the Express Checkout Element callbacks.
+
+**Why:** Express Checkout (Apple Pay, Google Pay) collects shipping natively in the wallet UI. Adding it to the PI would conflict with the wallet's own address handling.
+
+**Invariant:** Never pass shipping data to the PI when Express Checkout is active. The wallet owns the shipping address.
+
+**Implementation:** `stripe-payment.service.ts` → `buildPaymentIntentCreateParams()`, checks `expressCheckout` flag.
+
+**What breaks if violated:** Stripe returns a validation error or the wallet shows conflicting shipping information.
+
+---
+
+## Rule 7: Express Checkout with a known customer binds `customer` and `setup_future_usage` on the PI
+
+**What:** When Express Checkout uses the `_Setup` path (CT session and cart available at button render time), the enabler sends `x-express-customer-session: true` on `GET /payments`. The processor uses this signal to include `customer` and `setup_future_usage` on the PI — the same as the standard embedded checkout path.
+
+When Express Checkout uses the `_SetupExpress` path (deferred, no session at render time), this header is never sent and the PI remains one-shot with no customer binding.
+
+**Why:** The `_Setup` path creates Stripe Elements with `customerOptions` and `setupFutureUsage`. The PI must match — Stripe rejects `confirmPayment` with a `setup_future_usage` mismatch error if they differ. Conditioning on `x-express-customer-session` (set only by the enabler when Elements was initialized with customer data) is the only reliable way to distinguish the two Express paths from the processor side.
+
+**Invariant:** `expressWithCustomer = expressCheckout && Boolean(stripeCustomerId) && expressCustomerSession`. All three conditions must be true. The header is the necessary gate — `stripeCustomerId` alone is insufficient because a CT customer can have a Stripe ID from a previous checkout while still using `_SetupExpress`.
+
+**Implementation:**
+
+- Enabler: `dropin-express.ts` → `getHeadersConfig()` — sets `x-express-customer-session: true` when `this.baseOptions.stripeCustomerId` is set
+- Route: `stripe-payment.route.ts` → reads `x-express-customer-session` header, passes `isExpressCustomerSession` to service
+- Service: `stripe-payment.service.ts` → `createPaymentIntentStripe(expressCheckout, expressCustomerSession)` and `buildPaymentIntentCreateParams()` (condition `!expressCheckout || expressWithCustomer`)
+- CORS: `server.ts` → `x-express-customer-session` in `allowedHeaders`
+
+**Closure criterion:** `grep -n 'expressWithCustomer' processor/src/services/stripe-payment.service.ts` — must appear in both the flag assignment and the spread condition. `grep -n 'x-express-customer-session' enabler/src/express/dropin-express.ts` — must appear in `getHeadersConfig()`.
+
+**What breaks if violated:** Elements carries `setup_future_usage` but the PI does not → Stripe rejects `confirmPayment`. Or PI carries `setup_future_usage` but Elements does not → same rejection, opposite direction.
+
+---
+
+## Rule 6: Amounts always in cents (integer), never decimals
+
+**What:** All amounts passed to Stripe and stored in CT are integers representing the smallest currency unit (cents for USD/EUR).
+
+**Why:** Floating-point math on currency values causes rounding errors. Stripe's API requires integers.
+
+**Invariant:** Never pass a decimal amount to Stripe. Never divide an amount and pass the result without rounding to integer.
+
+**Implementation:** `ctCartService.getPaymentAmount()` returns centAmount; passed directly to Stripe.
+
+**What breaks if violated:** Stripe rejects the request with a validation error, or — worse — accepts a rounded value that differs from the cart total, causing a mismatch between what was charged and what CT records.

--- a/context/business-rules/refunds-reversals.md
+++ b/context/business-rules/refunds-reversals.md
@@ -1,0 +1,87 @@
+# Business Rule: Refunds & Reversals
+
+## Overview
+
+Refunds and reversals are initiated via the CT Connect operation endpoint (`POST /payment-intents/:id`). The connector supports full refunds, partial refunds (with feature flag), and smart reversals that detect the correct operation automatically.
+
+---
+
+## Rule 1: Multiple refunds require the multi-operations feature flag
+
+**What:** If a refund is requested and the **CT payment** already has a successful Refund transaction, a warning is logged. Without `STRIPE_ENABLE_MULTI_OPERATIONS=true`, the operation still proceeds (Stripe `refunds.create` is called) but the warning signals an unexpected state.
+
+**Why:** By default, the connector is designed for single-refund scenarios. Multiple refunds on a single charge are an advanced use case that requires explicit opt-in to avoid accidental partial refunds.
+
+**Invariant:** When multiple refunds are needed on a single payment, `STRIPE_ENABLE_MULTI_OPERATIONS` must be enabled. Refunding without it is technically possible but unsupported.
+
+**Implementation:** `processor/src/services/stripe-payment.service.ts` → `refundPayment()` — calls `ctPaymentService.hasTransactionInState({ payment, transactionType: 'Refund', states: ['Success'] })` (CT-side check, not Stripe `refunds.list`).
+
+**What breaks if violated:** Partial refunds may succeed individually but the connector's CT state tracking may not correctly reflect cumulative refunded amounts.
+
+---
+
+## Rule 2: Reverse payment auto-detects the correct operation
+
+**What:** `reversePayment()` inspects the CT payment's transaction history (via `ctPaymentService.hasTransactionInState`) to determine what to do:
+
+- If a `Charge: Success` transaction exists and the payment has not already been reverted (no `Refund` or `CancelAuthorization` in `Success` **or `Pending`** state) → call `refundPayment()` with `request.payment.amountPlanned`.
+- Else if an `Authorization: Success` transaction exists and the payment has not already been reverted (same `Success`/`Pending` check) → call `cancelPayment()`.
+- Otherwise → throw `ErrorInvalidOperation('There is no successful payment transaction to reverse.')`.
+
+Note: `Pending` state is included in the "already reverted" check — a refund or cancel that is still in-flight blocks a second reversal attempt.
+
+**Why:** The caller of `reversePayment` shouldn't need to know whether a payment was captured or only authorized. The reversal logic handles both cases transparently.
+
+**Invariant:** `reversePayment()` must never call both refund and cancel. It picks exactly one path based on transaction state.
+
+**Implementation:** `processor/src/services/stripe-payment.service.ts` → `reversePayment()`
+
+**What breaks if violated:** A payment that was already captured could be canceled (which would fail at Stripe), or a payment that was only authorized could be refunded (which would also fail — there's nothing to refund yet).
+
+---
+
+## Rule 3: Refund outcome is RECEIVED — final state comes via webhook
+
+**What:** When `refundPayment()` succeeds, the function returns `{ outcome: PaymentModificationStatus.RECEIVED, pspReference: refund.id }`. The CT Refund transaction transitions to `Success` only when Stripe sends the `charge.refunded` webhook.
+
+**Why:** Stripe refunds are processed asynchronously. The refund creation call returns a refund object that may still be pending settlement.
+
+**Invariant:** Never mark a CT Refund transaction as `Success` synchronously in response to a refund API call. Always wait for the webhook.
+
+**Implementation:** `processor/src/services/stripe-payment.service.ts` → `refundPayment()` returns `RECEIVED`; the webhook path uses `processStripeEventRefunded()` (multi-ops) or `processStripeEvent()` (default), which delegate to `stripeEventConverter.populateTransactions()` (`charge.refunded` → `REFUND: SUCCESS` + `CHARGE_BACK: SUCCESS`).
+
+**What breaks if violated:** CT shows a successful refund that Stripe later fails, with no mechanism to correct it.
+
+---
+
+## Rule 4: Cancel operates on the PaymentIntent, not the Charge
+
+**What:** `cancelPayment()` calls `paymentIntents.cancel()`. It does not call `refunds.create()`.
+
+**Why:** Cancellation is only valid for PIs in `requires_capture` or `requires_confirmation` state. These have no charge yet. Calling refund on them would fail because there is nothing to refund.
+
+**Invariant:** Use `paymentIntents.cancel()` for authorizations; use `refunds.create()` for captured charges. Never mix them.
+
+**Implementation:** `stripe-payment.service.ts` → `cancelPayment()` vs `refundPayment()`
+
+**What breaks if violated:** Stripe returns an error trying to refund a PI that has no charge. The operation fails and CT state is not updated.
+
+---
+
+## Rule 5: Idempotency keys — known gap
+
+**What:** Idempotency keys are not consistently applied across all Stripe write operations. Current state:
+
+- `paymentIntents.create()` — uses `crypto.randomUUID()` per call (non-deterministic; a retry generates a different key and Stripe treats it as a new request)
+- `paymentIntents.update()` (metadata patch after PI creation) — uses a separate `crypto.randomUUID()`; same non-deterministic problem
+- `paymentIntents.capture()` — no idempotency key
+- `paymentIntents.cancel()` — no idempotency key
+- `refunds.create()` — no idempotency key
+
+**Why this matters:** Network failures can cause the same request to arrive at Stripe twice. Without a stable idempotency key, Stripe processes it as a new request — risking double-charge or double-refund.
+
+**Intended design:** Every Stripe mutating call should carry an idempotency key derived from a stable identifier (CT payment ID + operation type). The current implementation does not meet this standard.
+
+**What breaks:** On network timeout and retry, `paymentIntents.create` creates a duplicate PI (and a duplicate CT Payment if the first response was lost). Capture, cancel, and refund retries execute the operation twice.
+
+**Status:** Known gap — tracked for remediation. Do not document these operations as idempotent until keys are implemented.

--- a/context/business-rules/webhook-handling.md
+++ b/context/business-rules/webhook-handling.md
@@ -1,0 +1,94 @@
+# Business Rule: Webhook Handling
+
+## Overview
+
+Stripe webhooks are the mechanism by which asynchronous payment outcomes (charge success, refund, cancellation) are reflected in CT. The processor must process them reliably and idempotently.
+
+---
+
+## Rule 1: Webhook signature must be verified before any processing
+
+**What:** Every POST to `/stripe/webhooks` is verified using `stripe.webhooks.constructEvent()` with `STRIPE_WEBHOOK_SIGNING_SECRET` inside the route handler. The `StripeHeaderAuthHook` pre-handler runs first but only confirms that the `stripe-signature` header is present — it does not validate the signature itself.
+
+**Why:** Anyone can POST to a public webhook endpoint. Without signature verification, a malicious actor could send fake events to manipulate CT payment states.
+
+**Invariant:** If signature verification fails inside the handler, the request is rejected immediately with 400 and no event is processed.
+
+**Implementation:**
+
+- Header presence check: `processor/src/libs/fastify/hooks/stripe-header-auth.hook.ts` → `StripeHeaderAuthHook.authenticate()`
+- Cryptographic verification: `processor/src/routes/stripe-payment.route.ts` → `stripeWebhooksRoutes` handler — calls `stripeApi().webhooks.constructEvent(rawBody, signature, stripeWebhookSigningSecret)` and returns 400 on failure.
+
+**What breaks if violated:** Fraudulent webhook events could mark unpaid orders as paid, trigger refunds on valid payments, or cancel active authorizations.
+
+---
+
+## Rule 2: Webhooks are processed synchronously, then 200 is returned
+
+**What:** The webhook handler does not respond 200 early. After signature verification, all CT update work for the event runs to completion (`await`-ed) and only then is the 200 response sent.
+
+**Why:** Returning 200 only after processing means CT updates that fail (or throw) are still observable as a non-2xx response, which causes Stripe to retry. The trade-off is that slow processing can push Stripe close to its delivery timeout and trigger retries.
+
+**Invariant:** Processing happens within the request lifecycle. There is no queue or background job. If a handler throws before reaching `reply.status(200).send()`, Fastify returns 5xx and Stripe will retry.
+
+**Implementation:** `processor/src/routes/stripe-payment.route.ts` → `stripeWebhooksRoutes` handler — `await opts.paymentService.processStripeEvent(event)` (and friends) runs first, `reply.status(200).send()` is the final statement.
+
+**Note — limitation:** Several other docs and ADRs claim that 200 is sent "immediately" before processing. That is the documented intent for resilient webhook handling but is not how the current code behaves. Migrating to early-ack would require a background queue/worker; today, slow CT updates can result in Stripe retries and therefore duplicate processing.
+
+**What breaks if violated:** If processing throws or hangs, Stripe will retry the event. CT transaction creation is not natively idempotent (see Rule 5 for the payment-method exception), so retries can produce duplicate transactions on the CT Payment.
+
+---
+
+## Rule 3: Event-to-transaction mapping is deterministic
+
+**What:** Each Stripe event type maps to a fixed set of CT transaction types and states. The actual mapping in `populateTransactions()` is:
+
+| Stripe Event | CT Transactions Created |
+|---|---|
+| `payment_intent.succeeded` | CHARGE: SUCCESS |
+| `charge.succeeded` | AUTHORIZATION: SUCCESS |
+| `payment_intent.canceled` | AUTHORIZATION: FAILURE + CANCEL_AUTHORIZATION: SUCCESS |
+| `payment_intent.payment_failed` | AUTHORIZATION: FAILURE |
+| `payment_intent.requires_action` | (no case in converter — the dispatcher routes the event to `processStripeEvent()` which calls the converter; the converter `default` branch throws and the error is caught/logged in `processStripeEvent`. No CT transaction is created.) |
+| `charge.refunded` | REFUND: SUCCESS + CHARGE_BACK: SUCCESS |
+| `charge.updated` (multicapture, multi-ops only) | CHARGE: SUCCESS |
+
+**Why:** CT payment state must reflect the definitive outcome from Stripe. The mapping is fixed — it does not depend on current CT state.
+
+**Invariant:** The converter always produces the same output for the same input event. Never conditionally change the transaction type based on prior CT state.
+
+**Implementation:** `processor/src/services/converters/stripeEventConverter.ts` → `populateTransactions()`. The router in `processor/src/routes/stripe-payment.route.ts` dispatches each event type to either `processStripeEvent()`, `processStripeEventRefunded()` (multi-ops `charge.refunded`), or `processStripeEventMultipleCaptured()` (multi-ops `charge.updated`).
+
+**Note — limitation (`payment_intent.requires_action`):** The webhook dispatcher routes this event to `processStripeEvent()` even though the converter has no case for it. The converter throws `Unsupported event payment_intent.requires_action`, the error is swallowed by `processStripeEvent`'s try/catch, and CT is left unchanged. To map this event to a real CT transaction, add a case to `populateTransactions()` in `stripeEventConverter.ts`.
+
+**Note — limitation (`payment_intent.succeeded`):** The converter currently emits a `CHARGE: SUCCESS` transaction for `payment_intent.succeeded`, which conflates the "intent succeeded" event with a captured charge. The pairing of `charge.succeeded` → AUTHORIZATION:SUCCESS and `payment_intent.succeeded` → CHARGE:SUCCESS appears intentional for `automatic` capture mode (where both events arrive and together encode auth + capture), but it is brittle for `manual` capture and worth revisiting. Tracked location: `stripeEventConverter.ts` `case StripeEvent.PAYMENT_INTENT__SUCCEEDED`.
+
+**What breaks if violated:** CT and Stripe states diverge. Orders may appear paid when they are not, or appear pending when they are settled.
+
+---
+
+## Rule 4: `charge.refunded` uses enhanced processing when multi-operations is enabled
+
+**What:** When `STRIPE_ENABLE_MULTI_OPERATIONS=true`, `charge.refunded` is handled by `processStripeEventRefunded()`, which calls `stripe.refunds.list({ charge, created: { gte: charge.created }, limit: 2 })` and uses the most recent refund's `id`/`amount`/`currency` to populate the CT transaction. When disabled, it uses the standard `processStripeEvent()` which derives the amount from `charge.amount_refunded` (cumulative).
+
+**Why:** With multicapture/multirefund, there may be multiple partial refunds. The cumulative `amount_refunded` field on the charge would overstate per-refund transactions, so the enhanced handler narrows to a specific refund object.
+
+**Invariant:** When multi-operations is enabled, always use the enhanced refund handler. Never use the cumulative `amount_refunded` field for individual refund transactions.
+
+**Implementation:** `processor/src/routes/stripe-payment.route.ts` (dispatcher branch on `stripeEnableMultiOperations`) and `processor/src/services/stripe-payment.service.ts` → `processStripeEventRefunded()` vs `processStripeEvent()`.
+
+**What breaks if violated:** CT records incorrect refund amounts when multiple partial refunds exist on a single charge.
+
+---
+
+## Rule 5: Payment method storage from webhooks is idempotent
+
+**What:** On `payment_intent.succeeded` and `charge.succeeded`, the dispatcher calls `storePaymentMethod(event)` after `processStripeEvent(event)`. Before saving, it checks if a token with that value already exists in CT for the same customer + payment interface.
+
+**Why:** Stripe may deliver the same event more than once (at-least-once delivery). Duplicate payment method storage would create duplicate records in CT.
+
+**Invariant:** Always check `ctPaymentMethodService.getByTokenValue({ customerId, paymentInterface, tokenValue })` before calling `ctPaymentMethodService.save()`. If the token exists, return the existing record and skip the save.
+
+**Implementation:** `processor/src/services/stripe-payment.service.ts` → `savePaymentMethodIfNew()` (called from `storePaymentMethod()`). The dispatcher in `processor/src/routes/stripe-payment.route.ts` calls `storePaymentMethod` for both `payment_intent.succeeded` and `charge.succeeded`.
+
+**What breaks if violated:** Duplicate payment method tokens in CT. The customer would see the same card listed multiple times in their saved payment methods.

--- a/context/decisions/adr-001-payment-element-pci.md
+++ b/context/decisions/adr-001-payment-element-pci.md
@@ -1,0 +1,28 @@
+# ADR-001 — Stripe Payment Element for PCI Compliance Reduction
+
+**Status:** Accepted  
+**Date:** 2024
+
+## Context
+
+The connector must handle card payments without bringing the merchant's server into PCI DSS scope for cardholder data. Direct card collection (raw card numbers) would require SAQ D compliance — the most demanding level.
+
+## Decision
+
+Use **Stripe Payment Element** as the sole card collection mechanism. The Payment Element is an iframe-based component hosted by Stripe; card data never touches the merchant's server or the connector's processor.
+
+## Consequences
+
+- Merchant qualifies for **SAQ A** (lowest PCI scope) — iframe-based card collection
+- No card numbers, CVCs, or raw payment data pass through the processor
+- The connector stores only `PaymentMethod` IDs (tokenized references)
+- UI customization is limited to Stripe's Appearance API — no full HTML control over card fields
+- 3DS authentication is handled within the Payment Element iframe, not by the connector
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|---|---|
+| Stripe.js `CardElement` (legacy) | Deprecated; no support for wallets, Link, or bank methods in a single UI |
+| Custom card form + `stripe.createPaymentMethod()` | Increases PCI scope; requires explicit tokenization handling |
+| Hosted Payment Page (Stripe Checkout) | Loses full control of the checkout UX; redirects away from merchant storefront |

--- a/context/decisions/adr-002-server-side-confirmation.md
+++ b/context/decisions/adr-002-server-side-confirmation.md
@@ -1,0 +1,36 @@
+# ADR-002 — Server-Side Payment Intent Confirmation for 3DS Support
+
+**Status:** Accepted  
+**Date:** 2024
+
+## Context
+
+Stripe Payment Intents can be confirmed client-side (`stripe.confirmPayment()`) or server-side (`paymentIntents.confirm()` via API). The connector needs to support 3DS (Strong Customer Authentication) without relying on the browser completing the flow before the order is created in commercetools.
+
+## Decision
+
+The processor is the authority for transitioning the CT Payment to `AUTHORIZED`. The actual Stripe confirmation step is still triggered client-side by `stripe.confirmPayment()` (the Payment Element does the network call to Stripe), but the connector then re-validates the PI server-side before updating CT. Concretely:
+
+1. Client collects payment method via Payment Element
+2. Client calls `stripe.confirmPayment()` — Stripe returns `succeeded` / `requires_capture` / `requires_action`
+3. Client calls `POST /confirmPayments/:id` on the processor with the PI id
+4. Processor calls `stripe.paymentIntents.retrieve(piId)` and runs a 4-point check (PI retrievable, status in {`succeeded`, `requires_capture`}, `metadata.ct_payment_id` matches `paymentReference`, amount/currency match the CT `amountPlanned`)
+5. Processor calls `ctPaymentService.updatePayment` to mark the CT payment as `AUTHORIZED`
+
+`MERCHANT_RETURN_URL` is exposed to the client as `merchantReturnUrl` via `/config-element` and consumed by `stripe.confirmPayment({ return_url })` in the browser. The processor never sets `return_url` on the PaymentIntent itself.
+
+The processor does **not** call `stripe.paymentIntents.confirm()`; confirmation happens in the browser via Stripe.js. The "server-side" aspect is the validation and CT state transition.
+
+## Consequences
+
+- 3DS redirects are supported: `stripe.confirmPayment({ return_url: merchantReturnUrl })` is called browser-side; Stripe sends the customer back to `MERCHANT_RETURN_URL` after authentication
+- The processor acts as the authority for payment state — client cannot authorize payments without server validation
+- The 4-point validation prevents replay attacks (a client cannot authorize a different amount by swapping IDs)
+- Requires `MERCHANT_RETURN_URL` to be configured for redirect-based payment methods (iDEAL, Bancontact, etc.)
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|---|---|
+| Client-side `stripe.confirmPayment()` | State sync between Stripe and CT relies on the browser completing the flow; unreliable on page close or network drop |
+| Webhook-only confirmation | Too slow for synchronous checkout UX; introduces race conditions on the order page |

--- a/context/decisions/adr-003-ct-source-of-truth.md
+++ b/context/decisions/adr-003-ct-source-of-truth.md
@@ -1,0 +1,32 @@
+# ADR-003 — CT Payment Object as Source of Truth for Transaction State
+
+**Status:** Accepted  
+**Date:** 2024
+
+## Context
+
+Payment state lives in two systems simultaneously: Stripe (PaymentIntent status, charge events) and commercetools (Payment object with Transactions). A clear ownership rule is needed to avoid split-brain scenarios.
+
+## Decision
+
+The **CT Payment object is the source of truth for transaction state**. Stripe is the source of truth for money movement (actual charges, refunds, and amounts).
+
+Concretely:
+- CT Transaction `state` drives the connector's business logic (what operations are allowed)
+- Stripe events update CT — never the reverse
+- The connector never reads Stripe to determine "what happened"; it reads CT
+- Stripe `PaymentIntent` ID is stored as a CT Payment custom field and used as the lookup key
+
+## Consequences
+
+- Webhook handlers (`POST /stripe/webhooks`) are responsible for keeping CT in sync with Stripe events
+- The connector uses CT's **optimistic locking** (`payment.version`) on every update to prevent concurrent writes
+- If a webhook fails and CT is out of sync, the CT payment is the stale record — not Stripe
+- Idempotency: webhook handlers must be safe to re-process (same Stripe event processed twice must produce the same CT state)
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|---|---|
+| Stripe as source of truth | Requires polling or webhooks to drive CT state; CT becomes eventually consistent without a clear single owner |
+| Dual source of truth | Leads to split-brain in partial failure scenarios (webhook delayed, CT update fails) |

--- a/context/decisions/adr-004-multi-capture.md
+++ b/context/decisions/adr-004-multi-capture.md
@@ -1,0 +1,34 @@
+# ADR-004 — Multi-Capture as Opt-In Feature
+
+**Status:** Accepted  
+**Date:** 2024
+
+## Context
+
+Standard payment capture is all-or-nothing: once captured, a PaymentIntent is closed. Some merchants need partial captures (e.g., split-shipment fulfillment where items ship at different times and amounts are captured per shipment).
+
+Stripe supports partial capture natively, but it adds complexity to refund tracking and balance transaction reconciliation.
+
+## Decision
+
+Multi-capture (partial captures + multiple refunds on a single PI) is **opt-in** via the environment variable `STRIPE_ENABLE_MULTI_OPERATIONS=true`. When disabled (default), the connector enforces single full capture.
+
+When enabled:
+- Multiple `POST /payment-intents/:id` capture calls are allowed on the same PI
+- Partial capture amounts are reconciled by calling `balanceTransactions.list()` on `charge.updated` events
+- Refunds use `refunds.list()` for tracking (not balance transactions)
+- CT Transaction history reflects each partial capture as a separate `CHARGE` transaction
+
+## Consequences
+
+- Default behavior (disabled) is simpler and less error-prone for most merchants
+- Enabling multi-capture requires the merchant to configure Stripe's `capture_method: manual` on PaymentIntents
+- Partial refunds require balance transaction lookups, which adds one extra Stripe API call per refund operation
+- CT's transaction model needs to support multiple `CHARGE` transactions on a single Payment object
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+|---|---|
+| Always-on multi-capture | Increases complexity for all merchants; most don't need it |
+| Separate connector for multi-capture | Duplicates codebase; a feature flag is sufficient |

--- a/context/decisions/adr-005-express-customer-binding.md
+++ b/context/decisions/adr-005-express-customer-binding.md
@@ -1,0 +1,84 @@
+# ADR-005 — Express Checkout Customer Binding When Session Is Available at Render Time
+
+**Status:** Accepted  
+**Date:** 2026-05-20
+
+## Context
+
+Express Checkout (Apple Pay / Google Pay) has two initialization paths:
+
+- **`_SetupExpress` (deferred):** No CT session at render time. Stripe Elements is created lazily inside `init()`, without `customerOptions` or `setupFutureUsage`. The PI is created one-shot with no customer binding.
+- **`_Setup` (upfront):** A CT session and cart are available before the buttons render. Stripe Elements is created in `getElements()` with `customerOptions`, `setupFutureUsage`, and `customerSessionClientSecret` — identical to the standard embedded checkout initialization.
+
+The original implementation blocked `customer` and `setup_future_usage` on the PI unconditionally whenever `x-express-checkout: true` was set, with the comment: _"no customer/setup_future_usage so the PI matches frontend Elements (created without them)."_
+
+This comment was accurate for `_SetupExpress` but incorrect for `_Setup`: in the `_Setup` path, Elements already carries `setupFutureUsage`. The block created an inconsistency — Elements signaled the save intent to Stripe, but the PI did not — causing Stripe to reject the `confirmPayment` call with a `setup_future_usage` mismatch error.
+
+A naive fix of conditioning solely on `stripeCustomerId` on the processor side was rejected: it activates for any express checkout where the CT customer happened to have a `stripeCustomerId` from a previous checkout, including `_SetupExpress` flows where Elements was created without `setupFutureUsage`. This introduced the opposite mismatch (PI has `off_session`, Elements has `null`).
+
+## Decision
+
+The enabler signals to the processor whether Elements was initialized with customer data by sending an `x-express-customer-session: true` header in `GET /payments`. This header is only sent when `this.baseOptions.stripeCustomerId` is set — which happens exclusively in the `_Setup` path where `GET /customer/session` resolved a Stripe customer.
+
+**Enabler** (`dropin-express.ts` → `getHeadersConfig()`):
+
+```ts
+if (this.baseOptions.stripeCustomerId) {
+  headers['x-express-customer-session'] = 'true';
+}
+```
+
+**Processor route** (`stripe-payment.route.ts`):
+
+```ts
+const isExpressCustomerSession =
+  request.headers['x-express-customer-session'] === 'true';
+const resp = await opts.paymentService.createPaymentIntentStripe(isExpressCheckout, isExpressCustomerSession);
+```
+
+**Processor service** (`stripe-payment.service.ts` → `createPaymentIntentStripe()`):
+
+```ts
+const expressWithCustomer = expressCheckout && Boolean(stripeCustomerId) && expressCustomerSession;
+```
+
+The PI condition in `buildPaymentIntentCreateParams()`:
+
+```ts
+// before
+...(!expressCheckout && stripeCustomerId && { customer, setup_future_usage })
+// after
+...((!expressCheckout || expressWithCustomer) && stripeCustomerId && { customer, setup_future_usage })
+```
+
+**CORS** (`server.ts`): `x-express-customer-session` added to `allowedHeaders`.
+
+The `_SetupExpress` path never sets `baseOptions.stripeCustomerId`, so it never sends the header, and `expressWithCustomer` remains `false`. Behavior for that path is unchanged.
+
+## Alternatives Considered
+
+| Alternative | Why discarded |
+|---|---|
+| Block `setup_future_usage` on all Express paths | Breaks saved payment methods for merchants who provide a session at render time; Elements and PI stay inconsistent |
+| Condition solely on `stripeCustomerId` in processor | Activates for `_SetupExpress` when CT customer has a prior `stripeCustomerId`, causing the opposite mismatch (PI has `off_session`, Elements has `null`) |
+| Always resolve customer in `_SetupExpress` | Requires `GET /customer/session` at button render time, not possible without a session |
+| Separate endpoint for Express-with-customer | Duplicates PI creation logic; a flag and header in the existing flow is sufficient |
+
+## Consequences
+
+**Positive:**
+
+- Express Checkout with `_Setup` path now correctly binds `customer` and `setup_future_usage` on the PI, consistent with Elements
+- `_SetupExpress` path is completely unaffected — no behavior change for deferred flows
+- Standard embedded checkout is unaffected
+- `off_session` for recurring carts (Rule 3, `customer-session.md`) applies to Express-with-customer as well
+
+**Negative:**
+
+- The enabler now sends an additional header on `GET /payments` in the `_Setup` path; CORS allowedHeaders must include it
+- The condition in `buildPaymentIntentCreateParams()` is slightly more complex
+
+**Risks:**
+
+- Stripe API behavior for `setup_future_usage=off_session` combined with `automatic_payment_methods: { enabled: true }` and wallet payment methods should be verified against Stripe documentation — if any automatically enabled method does not support off-session reuse, Stripe may return an error at PI creation
+- KI-008 still applies: if `getCtCustomer()` silently fails, `stripeCustomerId` is absent, `expressWithCustomer` is `false`, and the method is not saved, with no error surfaced to the caller

--- a/context/deployment.md
+++ b/context/deployment.md
@@ -1,0 +1,132 @@
+# Deployment — ct-connect-stripe-checkout
+
+Prerequisites, configuration, and deploy/undeploy lifecycle for CT Connect. Source of truth: `connect.yaml`.
+
+---
+
+## Prerequisites
+
+Complete these steps before deploying. Skipping any will cause silent failures.
+
+### Stripe account
+
+- [ ] Create a Webhook Endpoint in Stripe Dashboard pointing to `<CONNECT_SERVICE_URL>/stripe/webhooks`
+- [ ] Note the Webhook Endpoint ID (`we_*****`) — required as `STRIPE_WEBHOOK_ID`
+- [ ] Note the Webhook Signing Secret (`whsec_*****`) — required as `STRIPE_WEBHOOK_SIGNING_SECRET`
+- [ ] Note the Publishable Key (`pk_*****`) and Secret Key (`sk_*****`)
+- [ ] If using `STRIPE_ENABLE_MULTI_OPERATIONS=true`: enable multicapture in Stripe Dashboard → Settings → Payment capturing
+- [ ] If using Apple Pay: obtain the domain association file from Stripe Dashboard and host it at `/.well-known/apple-developer-merchantid-domain-association` on the storefront
+
+### commercetools project
+
+- [ ] API client with these scopes on `CTP_CLIENT_ID`:
+  - `manage_payments`
+  - `manage_orders`
+  - `view_sessions`
+  - `view_api_clients`
+  - `manage_checkout_payment_intents`
+  - `introspect_oauth_tokens`
+  - `manage_types`
+  - `view_types`
+- [ ] **Launchpad custom type created manually** (see `context/known-issues.md` KI-004) — `post-deploy` does NOT auto-create it. Key: `payment-launchpad-purchase-order` (configurable via `CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY`). Fields: `launchpadPurchaseOrderNumber` (String), `launchpadPurchaseOrderInvoiceMemo` (String).
+
+---
+
+## Environment Variables
+
+### Standard configuration (not encrypted)
+
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `CTP_PROJECT_KEY` | Yes | — | CT project key |
+| `CTP_AUTH_URL` | Yes | `https://auth.europe-west1.gcp.commercetools.com` | |
+| `CTP_API_URL` | Yes | `https://api.europe-west1.gcp.commercetools.com` | |
+| `CTP_SESSION_URL` | Yes | `https://session.europe-west1.gcp.commercetools.com` | |
+| `CTP_CHECKOUT_URL` | Yes | — | |
+| `CTP_JWKS_URL` | Yes | `https://mc-api.europe-west1.gcp.commercetools.com/.well-known/jwks.json` | |
+| `CTP_JWT_ISSUER` | Yes | `https://mc-api.europe-west1.gcp.commercetools.com` | |
+| `STRIPE_WEBHOOK_ID` | Yes | — | `we_*****` from Stripe Dashboard; used by `post-deploy` to update the webhook URL |
+| `STRIPE_PUBLISHABLE_KEY` | Yes | — | `pk_*****`; returned to the frontend via `/config` and `/express-config` |
+| `STRIPE_API_VERSION` | Yes | — | Stripe API version for ephemeral keys (must match the mobile SDK version if used) |
+| `MERCHANT_RETURN_URL` | Yes | — | Base URL for 3DS and redirect-based payment method returns; `cartId` and `paymentReference` are appended as query params |
+| `STRIPE_COLLECT_BILLING_ADDRESS` | No | `auto` | `auto` \| `never` \| `if_required` |
+| `STRIPE_CAPTURE_METHOD` | No | `automatic` | `automatic` \| `automatic_async` \| `manual` |
+| `STRIPE_ENABLE_MULTI_OPERATIONS` | No | `false` | `true` \| `false` — requires multicapture enabled in Stripe account |
+| `STRIPE_APPEARANCE_PAYMENT_ELEMENT` | No | — | JSON string (Stripe Appearance API) for Payment Element styling |
+| `STRIPE_LAYOUT` | No | `{"type":"tabs","defaultCollapsed":false}` | JSON string; valid types: `tabs`, `accordion`, `auto` |
+| `STRIPE_SAVED_PAYMENT_METHODS_CONFIG` | No | `{"payment_method_save":"disabled"}` | JSON string for Payment Element saved methods feature |
+| `STRIPE_APPLE_PAY_WELL_KNOWN` | No | — | Raw string content of the Apple Pay domain association file, returned by `GET /applePayConfig` |
+| `STRIPE_PAYMENT_INTENT_SETUP_FUTURE_USAGE` | No | — | Sets PI `setup_future_usage`; overridden to `off_session` for recurring carts. Values `''`, `'none'`, `'null'`, `'undefined'` are treated as absent |
+| `ALLOWED_ORIGINS` | No | — | Comma-separated CORS origins for `POST /express-config` (e.g. `https://shop.example.com,https://checkout.example.com`) |
+| `PAYMENT_INTERFACE` | No | `checkout-stripe` | Written to `paymentMethodInfo.paymentInterface` on CT payments |
+| `CT_CUSTOM_TYPE_STRIPE_CUSTOMER_KEY` | No | `payment-connector-stripe-customer-id` | Key of the CT custom type that stores Stripe customer IDs on CT customers |
+| `CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY` | No | `payment-launchpad-purchase-order` | Key of the Launchpad custom type (must be pre-created; see Prerequisites) |
+| `CT_CUSTOM_TYPE_SUBSCRIPTION_LINE_ITEM_KEY` | No | `payment-connector-subscription-line-item-type` | Defined but not installed by post-deploy; for future recurring-payment features |
+| `CT_PRODUCT_TYPE_SUBSCRIPTION_KEY` | No | `payment-connector-subscription-information` | Defined but not installed by post-deploy; for future recurring-payment features |
+| `HEALTH_CHECK_TIMEOUT` | No | — | Timeout (ms) for the `/status` health check |
+| `LOGGER_LEVEL` | No | — | Log level (`debug`, `info`, `warn`, `error`) |
+
+### Secured configuration (encrypted by CT Connect)
+
+| Variable | Required | Notes |
+|---|---|---|
+| `CTP_CLIENT_SECRET` | Yes | CT API client secret |
+| `CTP_CLIENT_ID` | Yes | CT API client ID — must have the scopes listed in Prerequisites |
+| `STRIPE_SECRET_KEY` | Yes | `sk_*****` — never log, never expose to the frontend |
+| `STRIPE_WEBHOOK_SIGNING_SECRET` | Yes | `whsec_*****` — used by `stripe.webhooks.constructEvent()` |
+
+---
+
+## Deploy Lifecycle
+
+### Post-deploy (`npm run connector:post-deploy`)
+
+Runs `processor/src/connectors/post-deploy.ts`. Executed automatically by CT Connect after deployment.
+
+**What it does (in order):**
+
+1. **Check Launchpad custom type** — calls `getTypeByKey()` for `CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY`. Logs whether it exists. Does NOT create it. Fails silently if absent (see `known-issues.md` KI-004).
+2. **Update Stripe webhook** — retrieves the endpoint by `STRIPE_WEBHOOK_ID` and updates its URL to `<CONNECT_SERVICE_URL>/stripe/webhooks` with these enabled events:
+   - `charge.succeeded`
+   - `charge.updated`
+   - `charge.refunded`
+   - `payment_intent.succeeded`
+   - `payment_intent.canceled`
+   - `payment_intent.payment_failed`
+   - `payment_intent.requires_action`
+3. **Create customer custom type** — creates or updates `payment-connector-stripe-customer-id` with field `stripeConnector_stripeCustomerId`.
+
+> If `STRIPE_WEBHOOK_ID` is empty, step 2 is skipped with a warning. The webhook URL must be configured manually in the Stripe Dashboard.
+
+### Pre-undeploy (`npm run connector:pre-undeploy`)
+
+Runs `processor/src/connectors/pre-undeploy.ts`. Executed automatically by CT Connect before undeployment.
+
+**What it does:**
+
+1. Removes the customer custom type (`CT_CUSTOM_TYPE_STRIPE_CUSTOMER_KEY`)
+
+> The Launchpad custom type (`CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY`) is NOT removed on undeploy.
+> The subscription line-item type and subscription product type are not removed (they are not installed by post-deploy).
+
+---
+
+## Deployed Applications
+
+CT Connect deploys two applications from this connector (defined in `connect.yaml`):
+
+| Name | Type | Description |
+|---|---|---|
+| `enabler` | `assets` | Frontend JavaScript bundle — serves the Stripe Payment Element and Express Checkout dropin |
+| `processor` | `service` | Backend Node.js service — all Stripe and CT API calls, webhook handler |
+
+The processor exposes its root at `/`. The enabler is a static asset bundle consumed by the merchant's frontend.
+
+---
+
+## Validation After Deploy
+
+1. Stripe Dashboard → Webhooks → confirm the endpoint URL is updated and all 7 events are enabled
+2. CT Merchant Center → Types → confirm `payment-connector-stripe-customer-id` exists with field `stripeConnector_stripeCustomerId`
+3. Hit `GET <CONNECT_SERVICE_URL>/status` — expect `200 OK`
+4. Place a test payment end-to-end with a Stripe test card (`4242 4242 4242 4242`)

--- a/context/feature-scope.md
+++ b/context/feature-scope.md
@@ -1,0 +1,98 @@
+# Feature Scope — ct-connect-stripe-checkout
+
+What this connector supports, what it does not support, and what is partially supported or has known gaps. An LLM consulting this document should answer "not in scope for this connector" rather than inferring from general Stripe knowledge.
+
+---
+
+## Payment Models
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| One-time payments | ✅ Supported | Core use case |
+| Guest checkout | ✅ Supported | `/customer/session` returns 204 for guests; Payment Element works without a saved customer |
+| Authenticated customer checkout | ✅ Supported | Saves Stripe customer ID on CT customer |
+| Saved payment methods | ✅ Supported | Via Stripe customer session + ephemeral key |
+| Automatic capture | ✅ Supported | `STRIPE_CAPTURE_METHOD=automatic` (default) |
+| Manual capture (authorize now, capture later) | ✅ Opt-in | `STRIPE_CAPTURE_METHOD=manual` |
+| Multi-capture (partial captures) | ✅ Opt-in | `STRIPE_ENABLE_MULTI_OPERATIONS=true`; requires multicapture enabled on Stripe account |
+| Subscriptions / recurring billing | ❌ Not supported | Use `ct-connect-stripe-composable` |
+| SetupIntent (save now, charge later) | ❌ Not supported | CT custom types defined but not installed by this connector |
+| Mixed carts (subscription + one-time) | ❌ Not supported | — |
+| Free trials | ❌ Not supported | — |
+
+---
+
+## Payment Element and Express Checkout
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Stripe Payment Element (embedded) | ✅ Supported | All Stripe-supported payment methods surfaced automatically based on currency, country, and Stripe account settings |
+| Express Checkout Element (Apple Pay, Google Pay) | ✅ Supported | Including shipping address and rate change callbacks that update CT cart |
+| Hosted Payment Page (HPP) | ❌ Not supported | Defined in code but not exported from `enabler/src/main.ts` |
+| 3DS / SCA (Strong Customer Authentication) | ✅ Supported | Server-side PaymentIntent confirmation; `payment_intent.requires_action` is subscribed but has no handler — 3DS redirect handled client-side by Stripe.js |
+| Apple Pay domain verification | ✅ Supported | `/applePayConfig` endpoint returns domain association file (no auth required) |
+| Billing address collection | ✅ Configurable | `STRIPE_COLLECT_BILLING_ADDRESS`: `auto`, `never`, `if_required` |
+| Setup future usage (save card) | ✅ Configurable | `STRIPE_PAYMENT_INTENT_SETUP_FUTURE_USAGE` |
+
+---
+
+## Refunds
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Full refund | ✅ Supported | — |
+| Partial refund | ✅ Supported | — |
+| Multiple refunds on one payment | ✅ Opt-in | `STRIPE_ENABLE_MULTI_OPERATIONS=true` |
+| Idempotency on refund | ⚠️ Known gap | `refunds.create()` has no idempotency key — retrying after a network failure may create a duplicate refund. See `known-issues.md` KI-007. |
+
+---
+
+## Webhook Events
+
+Events registered in `processor/src/connectors/actions.ts`:
+
+| Event | Handled | Effect |
+| --- | --- | --- |
+| `charge.succeeded` | ✅ | Sets `AUTHORIZATION:SUCCESS` on CT payment (does NOT create a CHARGE transaction) |
+| `charge.updated` | ✅ | Creates `CHARGE:SUCCESS` transaction on CT payment; used for multi-capture delta tracking |
+| `charge.refunded` | ✅ | Creates `REFUND` transaction on CT payment |
+| `payment_intent.succeeded` | ✅ | Creates `CHARGE` transaction on CT payment |
+| `payment_intent.canceled` | ✅ | Creates `CANCEL_AUTHORIZATION` transaction |
+| `payment_intent.payment_failed` | ✅ | Updates CT payment state |
+| `payment_intent.requires_action` | ⚠️ Subscribed, no handler | Events are received and silently dropped — 3DS handled client-side by Stripe.js |
+
+Events **not registered** (Stripe does not deliver them):
+
+| Event | Status |
+| --- | --- |
+| `charge.dispute.*` | ❌ Not registered — disputes are manual |
+| Any `invoice.*` event | ❌ Not registered |
+| Any `customer.subscription.*` event | ❌ Not registered |
+
+**Note:** The CT data model includes a `CHARGE_BACK` transaction type, but no webhook handler or registered event covers disputes. Dispute handling is entirely manual.
+
+---
+
+## Integration with ct-stripe-tax
+
+| Integration | Status | Notes |
+| --- | --- | --- |
+| Stripe Tax (`ct-stripe-tax`) | ✅ Supported | Reads `connectorStripeTax_calculationReferences` from CT cart; forwards to Stripe PI only when **exactly one** reference is present. Zero or multiple references are silently ignored. |
+
+---
+
+## Out of Scope for This Connector
+
+| Feature | Why |
+| --- | --- |
+| Subscriptions | Requires `ct-connect-stripe-composable` |
+| CT coupon / discount → Stripe sync | Not implemented |
+| CT price → Stripe price sync | Not implemented |
+| Dispute / chargeback automation | No `charge.dispute.*` webhook handler; manual process required |
+| Stripe Connect (marketplace, split payments) | Handled by separate `mirakl-stripe` integration |
+| ACH / bank transfers | Not dedicated; Payment Element may surface it based on Stripe account settings |
+| BNPL (Klarna, Afterpay, Affirm) | Not dedicated; Payment Element may surface it based on Stripe account settings |
+| Stripe Terminal (in-person) | Not implemented |
+| Stripe Link | Surfaced by Payment Element only; no dedicated flow |
+| B2B Launchpad purchase orders | CT custom type is checked for existence on deploy but fields are not written by this connector |
+| Hosted Payment Page (HPP) | Defined in code but not exported |

--- a/context/index.md
+++ b/context/index.md
@@ -1,0 +1,79 @@
+﻿# Knowledge Base Index — ct-connect-stripe-checkout
+
+**What this connector covers:** Stripe Payment Element + Express Checkout integration for commercetools. Handles one-time payments, 3DS, refunds, multi-capture, and Stripe Tax forwarding.
+
+**What this connector does NOT cover:** Subscriptions, mixed carts, coupon sync, price sync. See `feature-scope.md → Out of Scope` for the full list.
+
+For questions about the Integration as a whole (failure modes, connector selection, shared payment rules), see `../../context/index.md`.
+
+---
+
+## Route by Question Type
+
+### "Can I / Is it possible to...?"
+
+| Question | Document |
+| --- | --- |
+| Does this connector support feature X? | `feature-scope.md` |
+| Can I do subscriptions with this connector? | `feature-scope.md → Out of Scope` — answer is no |
+| Can I do partial captures? | `feature-scope.md` + `business-rules/multi-operations.md` |
+| Can I save payment methods for future use? | `business-rules/customer-session.md` |
+| Does this connector handle 3DS? | `feature-scope.md` + `ARCHITECTURE.md` |
+
+### "How does X work?"
+
+| Question | Document |
+| --- | --- |
+| How does the payment flow work end to end? | `ARCHITECTURE.md` |
+| How are webhooks processed? | `business-rules/webhook-handling.md` |
+| How are refunds processed? | `business-rules/refunds-reversals.md` |
+| How does multi-capture work? | `business-rules/multi-operations.md` |
+| How does customer session / saved methods work? | `business-rules/customer-session.md` |
+| How does the payment lifecycle map to CT transactions? | `business-rules/payment-lifecycle.md` |
+
+### "What happens when X fails?"
+
+| Question | Document |
+| --- | --- |
+| What happens when Stripe is down? | `../../context/failure-modes.md` |
+| What happens when CT is down? | `../../context/failure-modes.md` |
+| What are the known technical gotchas? | `known-issues.md` |
+| What happens on a CT 409 conflict? | `known-issues.md` + `../../context/known-issues.md` |
+
+### "What are the rules for X?"
+
+| Question | Document |
+| --- | --- |
+| Rules for refunds | `business-rules/refunds-reversals.md` |
+| Rules for webhooks | `business-rules/webhook-handling.md` |
+| Rules for multi-capture | `business-rules/multi-operations.md` |
+| Universal Stripe + CT rules | `../../context/business-rules/stripe-ct-shared.md` |
+| Universal refund rules | `../../context/business-rules/refunds.md` |
+| Why was architectural decision X made? | `decisions/` |
+
+---
+
+## Reading Order by Role
+
+### Adopting this connector (installing for the first time)
+
+1. `adopter-guide.md` — prerequisites, deploy steps, env vars, enabler integration, verification
+
+### New to this connector (developer onboarding)
+
+1. `ARCHITECTURE.md` — system overview, components, API endpoints
+2. `feature-scope.md` — what's supported and what's not
+3. `business-rules/payment-lifecycle.md` — how payments flow through Stripe and CT
+4. `known-issues.md` — gotchas specific to this connector
+
+### Implementing a feature
+1. Read hub `CLAUDE.md` + `../../context/known-issues.md` first
+2. Read `ARCHITECTURE.md` for the relevant component
+3. Read the `business-rules/` file for the domain being touched
+4. Check `feature-scope.md` to confirm the feature is in scope
+
+### Debugging a payment issue
+1. `known-issues.md` — connector-specific gotchas
+2. `../../context/known-issues.md` — hub-level gotchas (409, webhook duplicates)
+3. `business-rules/payment-lifecycle.md` — expected state transitions
+4. `business-rules/webhook-handling.md` — expected webhook behavior

--- a/context/known-issues.md
+++ b/context/known-issues.md
@@ -1,0 +1,150 @@
+# Known Issues — ct-connect-stripe-checkout
+
+Connector-specific limitations, code defects, and operational gotchas. Cross-cutting issues (webhook swallow, idempotency, CORS, credential defaults) are also documented in the hub `context/known-issues.md` — cross-references are noted below.
+
+---
+
+## KI-001: Webhook event handlers swallow all errors → HTTP 200 on CT update failure → permanent state divergence
+
+**Problem:** `processStripeEvent()`, `processStripeEventRefunded()`, `processStripeEventMultipleCaptured()`, and `storePaymentMethod()` each contain a top-level try/catch that logs the exception and returns void. The route handler then returns HTTP 200 to Stripe, which considers the event delivered and never retries. The CT payment object is left in an inconsistent state with no automatic recovery.
+**Root cause:** `processor/src/services/stripe-payment.service.ts:959, 1080, 1128, 1032` — all event processing functions absorb exceptions before they can bubble to the route layer.
+**Rule:** Webhook handlers must return HTTP 5xx when CT update fails so Stripe retries. See hub `known-issues.md` Issue 1.
+**Implementation note:** Affected events: `charge.succeeded`, `charge.updated`, `charge.refunded`, `payment_intent.succeeded`, `payment_intent.canceled`, `payment_intent.payment_failed`.
+
+---
+
+## KI-002: capturePayment/cancelPayment/refundPayment catch Stripe errors and return REJECTED with no CT state update
+
+**Problem:** `capturePayment()`, `cancelPayment()`, and `refundPayment()` each have a try/catch that catches Stripe API errors and returns `{ outcome: 'REJECTED' }` with HTTP 200. When Stripe rejects the operation, no CT Payment transaction is written and the CT payment state is not updated to reflect the failure.
+**Root cause:** `processor/src/services/stripe-payment.service.ts:232, 265, 318` — error is caught, logged, and converted to REJECTED outcome without updating CT.
+**Rule:** After a Stripe operation failure, the CT payment must be updated to a FAILED state before returning. See hub `failure-modes.md — Stripe API: Payment Intent operations`.
+**Implementation note:** The operator dashboard shows REJECTED with no Stripe error details. CT/Stripe divergence requires manual reconciliation.
+
+---
+
+## KI-003: Global CORS `origin: '*'` on all Fastify routes — any domain can call payment endpoints
+
+**Problem:** Fastify is configured with `origin: '*'` globally in `processor/src/server/server.ts:43`. Every route — including `GET /payments`, `POST /confirmPayments/:id`, `GET /customer/session` — accepts cross-origin requests from any domain. The per-route `ALLOWED_ORIGINS` check applies only to `/express-config` via `corsAuthHook`.
+**Root cause:** `processor/src/server/server.ts:43` — CORS configured globally with no origin restriction.
+**Rule:** CORS must restrict origins to the known storefront domains. `origin: '*'` is appropriate only for fully public unauthenticated endpoints. See hub `known-issues.md` Issue 15.
+**Implementation note:** `GET /applePayConfig` is intentionally public (Apple Pay domain verification). Other endpoints have session-header auth that mitigates the impact but does not eliminate CORS exposure.
+
+---
+
+## KI-004: `handleRequest()` in `actions.ts` does not await async post-deploy functions
+
+**Problem:** `handleRequest()` at `processor/src/connectors/actions.ts:32` is async but the functions it invokes (`createCustomerIdCustomType()`, `createLaunchpadPurchaseOrderNumberCustomType()`, etc.) are awaited only partially — the top-level caller of `handleRequest` does not await its result. Post-deploy functions may fail silently and the deploy succeeds regardless.
+**Root cause:** `processor/src/connectors/actions.ts:32` — missing await on async function call.
+**Rule:** All async post-deploy lifecycle functions must be awaited with their errors propagated to the CT Connect SDK to fail the deploy.
+**Implementation note:** If a custom type creation fails silently, the connector starts without the required custom type and runtime calls that depend on it produce confusing errors.
+
+---
+
+## KI-005: `retrieveWebhookEndpoint()` and `updateWebhookEndpoint()` errors swallowed in post-deploy
+
+**Problem:** Both functions in `processor/src/connectors/actions.ts:54, 65` catch errors and only log them. If the Stripe webhook endpoint update fails during post-deploy, the deploy succeeds but the connector is registered at the old webhook URL. All incoming Stripe events are delivered to the stale endpoint, which may belong to a different environment.
+**Root cause:** `processor/src/connectors/actions.ts:54–65` — try/catch absorbs Stripe errors without re-throwing.
+**Rule:** Post-deploy failures that affect event delivery must abort the deploy. See hub `known-issues.md` Issue 6.
+**Implementation note:** See hub `failure-modes.md — Stripe API: Webhook endpoint update fails at post-deploy`.
+
+---
+
+## KI-006: Enabler throws a string literal on `/confirmPayments` failure instead of an `Error` object
+
+**Problem:** At `enabler/src/dropin/dropin-embedded.ts:189`, when `POST /confirmPayments/:id` fails, the code executes `throw response.errors[0]` or a similar string literal. Throwing a non-Error object causes catch handlers to receive a string, which breaks `error.message`, `error.stack`, and any instanceof checks in the host application.
+**Root cause:** `enabler/src/dropin/dropin-embedded.ts:189` — throws a raw string or plain object, not a wrapped `Error`.
+**Rule:** All throw sites must throw an `Error` instance or a subclass. Throwing strings breaks error propagation in TypeScript and host applications.
+**Implementation note:** Host apps that catch this error and read `.message` or `.stack` will get `undefined`.
+
+---
+
+## KI-007: Idempotency keys are `crypto.randomUUID()` on PI create; absent on capture/cancel/refund
+
+**Problem:** `paymentIntents.create()` uses `crypto.randomUUID()` as idempotency key — a different value is generated each call, so retries create duplicate PIs. `paymentIntents.capture()`, `paymentIntents.cancel()`, and `refunds.create()` carry no idempotency key — retries after network timeouts may double-capture, double-cancel, or double-refund.
+**Root cause:** `processor/src/services/stripe-payment.service.ts:498` (create), `580` (update), `211` (capture), `250` (cancel), `303` (refund) — no stable idempotency keys derived from CT payment ID.
+**Rule:** Every Stripe write must carry a key derived from a stable CT identifier (CT payment ID + operation type suffix). See hub `known-issues.md` Issue 7.
+**Implementation note:** Workaround: disable HTTP retries at the infrastructure level on outbound Stripe calls.
+
+---
+
+## KI-008: `getCtCustomer()` swallows all CT lookup errors with `.catch(() => undefined)`
+
+**Problem:** At `processor/src/services/stripe-payment.service.ts:1255`, `getCtCustomer()` is called with `.catch(() => undefined)`. Any CT API error — including 500, network failure, or auth failure — is silently treated as "customer not found" and the connector continues as if the customer does not exist. A new Stripe customer may be created unnecessarily.
+**Root cause:** `processor/src/services/stripe-payment.service.ts:1255` — blanket catch swallows all errors.
+**Rule:** Only `404 Not Found` should be treated as "customer not found". All other errors must propagate.
+**Implementation note:** Creates duplicate Stripe customers during CT API instability.
+
+---
+
+## KI-009: `fetchConfigData()` has no `response.ok` check — non-2xx config responses parsed as success
+
+**Problem:** At `enabler/src/payment-enabler/payment-enabler-mock.ts:289`, `fetchConfigData()` calls `fetch()` and immediately calls `.json()` on the response without checking `response.ok`. A 400 or 500 error response with a JSON body is parsed as a configuration object. The connector initializes with garbage config silently.
+**Root cause:** `enabler/src/payment-enabler/payment-enabler-mock.ts:289` — missing `if (!response.ok) throw new Error(...)` guard.
+**Rule:** Every `fetch()` call must check `response.ok` before parsing the body.
+
+---
+
+## KI-010: `getCustomerOptions()` has no `response.ok` check — non-204 error responses treated as guest checkout
+
+**Problem:** At `enabler/src/payment-enabler/payment-enabler-mock.ts:330`, `getCustomerOptions()` treats any non-204 response (including 400 and 500 errors from the processor) as "guest checkout" and returns null. A server error during customer session setup silently degrades to guest mode without notifying the host application.
+**Root cause:** `enabler/src/payment-enabler/payment-enabler-mock.ts:330` — status code check is `=== 204` only; any other status (including error codes) falls through to the null return.
+**Rule:** Error status codes must be distinguished from intentional 204 No Content. See hub `business-rules/customer-data.md`.
+
+---
+
+## KI-011: `paymentIntents.update()` metadata patch is a separate Stripe call — failure orphans the CT Payment
+
+**Problem:** `GET /payments` creates the PI, creates the CT Payment, adds the payment to the cart, then calls `paymentIntents.update()` to write `ct_payment_id` to PI metadata as a separate call. If this update fails, the CT Payment exists but the PI has no `ct_payment_id`. Webhook events for that PI cannot be matched to a CT Payment and are silently dropped.
+**Root cause:** `processor/src/services/stripe-payment.service.ts:581` — metadata patch is not atomic with PI creation; no rollback on failure.
+**Rule:** PI metadata must be written atomically at PI creation or via a reliable background retry. No CT Payment state should depend on a metadata field that can be lost. See hub `failure-modes.md — CT Platform API: CT unavailable`.
+**Implementation note:** Orphaned PIs expire automatically (uncaptured manual PIs in 7 days; automatic PIs generate no charge). No automatic cleanup mechanism.
+
+---
+
+## KI-012: `STRIPE_WEBHOOK_SIGNING_SECRET` defaults to `''` — all webhooks silently rejected if not set
+
+**Problem:** `processor/src/config/config.ts:36` defaults `STRIPE_WEBHOOK_SIGNING_SECRET` to `''`. If the env var is absent, `stripe.webhooks.constructEvent()` is called with an empty secret and throws `SignatureVerificationException` for every incoming webhook. The handler returns HTTP 400; Stripe retries for 72 hours then gives up. All webhook-driven CT updates fail permanently.
+**Root cause:** `processor/src/config/config.ts:36` — empty string default with no startup validation.
+**Rule:** `STRIPE_WEBHOOK_SIGNING_SECRET` must be validated as non-empty at startup. See hub `known-issues.md` Issue 4.
+
+---
+
+## KI-013: `STRIPE_SECRET_KEY` defaults to `'stripeSecretKey'` — invalid credentials accepted at startup
+
+**Problem:** `processor/src/config/config.ts:35` defaults `STRIPE_SECRET_KEY` to the literal `'stripeSecretKey'`. If the env var is not set, the server starts normally and makes Stripe API calls with an invalid key, producing authentication errors at runtime rather than a startup failure.
+**Root cause:** `processor/src/config/config.ts:35` — placeholder default with no startup validation.
+**Rule:** Required credentials must be validated at startup. A server that starts with placeholder credentials is worse than one that fails fast. See hub `known-issues.md` Issue 5.
+
+---
+
+## KI-014: `charge.succeeded` converter records `amount_refunded=0` as `centAmount` on the AUTHORIZATION transaction
+
+**Problem:** At `processor/src/services/converters/stripeEventConverter.ts:116`, the converter for `charge.succeeded` reads `charge.amount_refunded` (which is `0` at creation) and writes it as the `centAmount` on the `AUTHORIZATION:SUCCESS` transaction. This creates an AUTHORIZATION transaction with `centAmount = 0`, which is misleading — the authorization amount should be `charge.amount`.
+**Root cause:** `processor/src/services/converters/stripeEventConverter.ts:116` — wrong field used for the authorization amount.
+**Rule:** `AUTHORIZATION` transaction `centAmount` must be set from `charge.amount`, not `charge.amount_refunded`.
+
+---
+
+## KI-015: `cancelPayment()` converter records full PI amount as `CANCEL_AUTHORIZATION` centAmount
+
+**Problem:** At `processor/src/services/converters/stripeEventConverter.ts:129`, the `CANCEL_AUTHORIZATION` transaction created by `cancelPayment()` records the full `payment_intent.amount` rather than the actual canceled amount. For partial captures with a residual amount, the cancel record is inaccurate.
+**Root cause:** `processor/src/services/converters/stripeEventConverter.ts:129` — uses PI total amount, not the residual uncaptured amount.
+**Rule:** `CANCEL_AUTHORIZATION` centAmount must reflect the actual amount being canceled, not the original PI amount.
+
+---
+
+## KI-016: `createLaunchpadPurchaseOrderNumberCustomType()` sends an empty body to CT
+
+**Problem:** At `processor/src/connectors/actions.ts:41`, `createLaunchpadPurchaseOrderNumberCustomType()` is called but the request body sent to CT is missing the field definitions. The function checks for existence of the custom type but does not create or update it — the body sent to the CT API is empty `{}`.
+**Root cause:** `processor/src/connectors/actions.ts:41` — the custom type create call omits the fields array.
+**Rule:** Post-deploy must either create the custom type with its required fields or fail loudly if the type is absent. Silent no-op is not acceptable.
+**Implementation note:** The `payment-launchpad-purchase-order` custom type must be created manually before deploying. See `business-rules/` for required field definitions.
+
+---
+
+## KI-017: `payment_intent.requires_action` is registered in the webhook endpoint but has no handler — events silently dropped
+
+**Problem:** `payment_intent.requires_action` is listed in the `enabledEvents` array in `processor/src/connectors/actions.ts` and is delivered by Stripe. Inside `processStripeEvent()`, the converter has no case for this event type and throws `Unsupported event ...`, which is caught by the error-swallowing try/catch (KI-001). No CT update is made.
+**Root cause:** `processor/src/connectors/actions.ts` (event registration) + `processor/src/services/converters/stripeEventConverter.ts` (no case for `payment_intent.requires_action`).
+**Rule:** Every registered webhook event must have a handler. Remove from `enabledEvents` if not handled, or implement the handler.
+**Implementation note:** 3DS is handled client-side by Stripe.js before the webhook arrives. The webhook event is not strictly necessary for the current flow but its silent drop masks any edge case where 3DS fails asynchronously.

--- a/context/reference/ct-connect-payments-sdk.md
+++ b/context/reference/ct-connect-payments-sdk.md
@@ -1,0 +1,84 @@
+# Reference — CT Connect Payments SDK
+
+Package: `@commercetools/connect-payments-sdk@0.27.2` (pinned in `processor/package.json`)
+
+## What the SDK Provides
+
+The CT Connect Payments SDK is the framework layer for commercetools Connect payment connectors. It handles:
+
+- **Session management** — `SessionHeaderAuthenticationHook` validates the `x-session-id` header on frontend-facing endpoints
+- **OAuth2 auth** — `OAuth2AuthenticationHook` validates JWT tokens on back-office endpoints (capture, cancel, refund)
+- **CT API client** — Pre-configured `commercetools/platform-sdk` client with automatic token refresh
+- **Payment service wrappers** — `CtPaymentService`, `CtCartService`, `CtCustomerService` with typed methods
+- **Error classes** — `CommercetoolsError`, `StripeError` mapped to HTTP responses
+- **Connect lifecycle hooks** — `post-deploy.js` / `pre-undeploy.js` runner for connector installation
+
+## Auth Middleware Used in This Connector
+
+| Route group | Middleware | Header |
+|---|---|---|
+| Frontend payment routes | `SessionHeaderAuthenticationHook` | `x-session-id` |
+| CT Connect operations (capture/cancel/refund) | `OAuth2AuthenticationHook` | `Authorization: Bearer <jwt>` |
+| `/express-config` | None (public CORS) | — |
+| `/stripe/webhooks` | Stripe signature (`stripe-signature`) | — |
+
+## Key Service Methods (as called by this connector)
+
+The exact SDK signatures live in `node_modules/@commercetools/connect-payments-sdk/dist/...`. The shapes below describe how the connector invokes them; the SDK accepts a single options object on each call rather than positional arguments.
+
+### CommercetoolsPaymentService
+
+- `getPayment({ id })` → `Promise<Payment>`
+- `createPayment(draft)` → `Promise<Payment>` (draft includes `amountPlanned`, `paymentMethodInfo`, `transactions`, optional `customer`/`anonymousId`)
+- `updatePayment({ id, transaction?, paymentMethodInfo?, pspReference?, pspInteraction?, ... })` → `Promise<Payment>` (options object; the connector spreads converter output and passes a `transaction` per loop iteration)
+- `hasTransactionInState({ payment, transactionType, states })` → `boolean` (used by `refundPayment`/`reversePayment`)
+
+### CommercetoolsCartService
+
+- `getCart({ id })` → `Promise<Cart>`
+- `addPayment({ resource: { id, version }, paymentId })` → `Promise<Cart>`
+- `getPaymentAmount({ cart })` → `Promise<{ centAmount, currencyCode }>`
+- `isRecurringCart?(cart)` → optional, may be unavailable in older SDK versions; called with optional chaining
+
+### CommercetoolsPaymentMethodService
+
+- `getByTokenValue({ customerId, paymentInterface, tokenValue })` → `Promise<PaymentMethod | undefined>` (throws `ErrorResourceNotFound` when absent in some SDK versions; the connector catches it)
+- `save({ customerId, paymentInterface, token, method })` → `Promise<PaymentMethod>`
+
+### Customer access (no dedicated SDK service used)
+
+The connector reads CT customers via the raw API client:
+
+- `paymentSDK.ctAPI.client.customers().withId({ ID }).get().execute()`
+- Updates go through `processor/src/services/commerce-tools/customerClient.ts` → `updateCustomerById({ id, version, actions })`
+
+## Connect Lifecycle
+
+```text
+Deploy → connector:post-deploy   (processor/src/connectors/post-deploy.ts)
+Undeploy → connector:pre-undeploy (processor/src/connectors/pre-undeploy.ts)
+```
+
+What `post-deploy` actually does today (`processor/src/connectors/post-deploy.ts` and `connectors/actions.ts`):
+
+1. Calls `createLaunchpadPurchaseOrderNumberCustomType()` — only **logs** if the type already exists (no creation logic in the function as written).
+2. If `STRIPE_WEBHOOK_ID` env var is set, retrieves the existing Stripe webhook endpoint and, if its URL differs from `${CONNECT_SERVICE_URL}stripe/webhooks`, calls `webhookEndpoints.update()` with the connector URL and the canonical `enabled_events` list (`charge.succeeded`, `charge.updated`, `payment_intent.succeeded`, `charge.refunded`, `payment_intent.canceled`, `payment_intent.payment_failed`, `payment_intent.requires_action`).
+3. If `STRIPE_WEBHOOK_ID` is not set, prints a stderr message asking the operator to register the webhook manually in the Stripe dashboard. It does **not** call `webhookEndpoints.create()` or persist a signing secret to CT.
+4. Calls `createOrUpdateCustomerCustomType()` to install the `payment-connector-stripe-customer-id` custom type (`stripeCustomerIdCustomType` in `custom-types.ts`).
+
+`STRIPE_WEBHOOK_SIGNING_SECRET` must be supplied via environment configuration; it is not auto-provisioned.
+
+## Optimistic Locking Pattern
+
+CT API requires the current `version` on every update. The SDK does NOT retry on `409 ConcurrentModification` — the connector must handle this:
+
+```typescript
+const payment = await ctPaymentService.getPayment(id); // get fresh version
+await ctPaymentService.updatePayment(payment, actions); // uses payment.version
+```
+
+## Official Docs
+
+- CT Connect Payments SDK: https://github.com/commercetools/connect-payment-integration-adyen (reference implementation)
+- CT Payments API: https://docs.commercetools.com/api/projects/payments
+- CT API Extension: https://docs.commercetools.com/api/projects/api-extensions

--- a/context/reference/stripe-v20-payment-intents.md
+++ b/context/reference/stripe-v20-payment-intents.md
@@ -1,0 +1,68 @@
+# Reference — Stripe API v20: Payment Intents
+
+Stripe SDK version used: `stripe@^20.1.0`
+
+## Key Changes in v20 (from v17–v19)
+
+- Full TypeScript strict-mode types for all API objects
+- Pagination via `autoPagingToArray()` and `autoPagingEach()` on list methods
+- `stripe.paymentIntents.create()` returns `Stripe.PaymentIntent` (typed)
+- `latest_charge` field on PaymentIntent is now a full `Stripe.Charge` object when expanded
+- `stripe.webhooks.constructEventAsync()` available for async webhook validation
+
+## Payment Intent Lifecycle
+
+```
+requires_payment_method → requires_confirmation → requires_action → processing → succeeded
+                                                                              ↘ canceled
+                                                                              ↘ requires_capture (manual)
+```
+
+## Key Parameters Used by This Connector
+
+| Parameter | Type | Purpose |
+|---|---|---|
+| `amount` | integer (cents) | Payment amount — always integer, never float |
+| `currency` | string (ISO 4217) | Lowercase currency code from CT cart |
+| `capture_method` | `automatic` \| `automatic_async` \| `manual` | Set by `STRIPE_CAPTURE_METHOD` env var |
+| `setup_future_usage` | `on_session` \| `off_session` | Set by `STRIPE_PAYMENT_INTENT_SETUP_FUTURE_USAGE` |
+| `metadata` | object | Stores CT cart ID, project key, payment ID |
+| `customer` | string (cus_xxx) | Stripe customer ID for saved payment methods |
+
+## Webhook Events Handled
+
+| Event | CT Action |
+|---|---|
+| `payment_intent.succeeded` | Add `CHARGE: SUCCESS` transaction (also triggers `storePaymentMethod`) |
+| `charge.succeeded` | Add `AUTHORIZATION: SUCCESS` transaction (also triggers `storePaymentMethod`) |
+| `payment_intent.canceled` | Add `AUTHORIZATION: FAILURE` + `CANCEL_AUTHORIZATION: SUCCESS` transactions |
+| `payment_intent.payment_failed` | Add `AUTHORIZATION: FAILURE` transaction |
+| `payment_intent.requires_action` | Routed to `processStripeEvent` but the converter has no case for it; the resulting `Unsupported event` error is swallowed and CT is not updated |
+| `charge.refunded` | Add `REFUND: SUCCESS` + `CHARGE_BACK: SUCCESS` transactions (multi-ops uses per-refund amount via `refunds.list`) |
+| `charge.updated` | Multi-ops only — add `CHARGE: SUCCESS` transaction with delta from `previous_attributes.amount_captured` |
+
+`charge.dispute.created` is **not** currently handled by this connector. Disputes/chargebacks have to be reflected manually or by adding a new case to the dispatcher and converter.
+
+## Idempotency
+
+All write operations require an idempotency key:
+```typescript
+stripe.paymentIntents.create(params, { idempotencyKey: `pi-${ctPaymentId}` })
+```
+
+Use a deterministic key based on the CT payment ID to ensure safe retries.
+
+## Apple Pay Domain Verification
+
+Stripe requires a domain association file at:
+```
+/.well-known/apple-developer-merchantid-domain-association
+```
+The processor serves this via `GET /applePayConfig` — the URL is set in `STRIPE_APPLE_PAY_WELL_KNOWN`.
+
+## Official Docs
+
+- Payment Intents API: https://stripe.com/docs/api/payment_intents
+- Stripe Node.js SDK: https://github.com/stripe/stripe-node
+- Migration guide v19→v20: https://github.com/stripe/stripe-node/wiki/Migration-guide-for-v20
+- Webhook signatures: https://stripe.com/docs/webhooks/signatures

--- a/context/workflows/process-capture-cancel.md
+++ b/context/workflows/process-capture-cancel.md
@@ -1,0 +1,119 @@
+# Workflow: Capture & Cancel (Manual Capture)
+
+**Trigger:** Merchant calls `POST /payment-intents/:id` with action `capturePayment` or `cancelPayment`. Only relevant when `STRIPE_CAPTURE_METHOD=manual`.
+**Actors:** Merchant backend / CT dashboard, Processor, Stripe API, CT API.
+**Outcome:** CT Payment updated with CHARGE (capture) or CANCEL_AUTHORIZATION (cancel).
+
+---
+
+## Prerequisites
+
+- `STRIPE_CAPTURE_METHOD=manual` must be configured
+- CT Payment must have an AUTHORIZATION transaction in SUCCESS state
+- For partial capture: `STRIPE_ENABLE_MULTI_OPERATIONS=true` must be configured
+
+---
+
+## Capture Flow
+
+```
+Merchant                  Processor                        Stripe          CT
+  |                           |                                |              |
+  | POST /payment-intents/:id |                                |              |
+  | { action: capturePayment, |                                |              |
+  |   amount? }               |                                |              |
+  |-------------------------->|                                |              |
+  |                           | getPayment() from CT           |              |
+  |                           |---------------------------------------------->|
+  |                           |                                |              |
+  |                           | if partial amount:             |              |
+  |                           |   check stripeEnableMultiOps   |              |
+  |                           |   if false → reject 400        |              |
+  |                           |                                |              |
+  |                           | paymentIntents.capture(        |              |
+  |                           |   piId,                        |              |
+  |                           |   { amount_to_capture?,        |              |
+  |                           |     final_capture: false })    |              |
+  |                           |-------------------------------->|              |
+  |                           |                                |              |
+  |                           | updatePayment(                 |              |
+  |                           |   CHARGE: SUCCESS,             |              |
+  |                           |   amount)                      |              |
+  |                           |---------------------------------------------->|
+  |   { outcome: RECEIVED }   |                                |              |
+  |<--------------------------|                                |              |
+```
+
+---
+
+## Cancel Flow
+
+```
+Merchant                  Processor                        Stripe          CT
+  |                           |                                |              |
+  | POST /payment-intents/:id |                                |              |
+  | { action: cancelPayment } |                                |              |
+  |-------------------------->|                                |              |
+  |                           | getPayment() from CT           |              |
+  |                           |---------------------------------------------->|
+  |                           |                                |              |
+  |                           | paymentIntents.cancel(piId)    |              |
+  |                           |-------------------------------->|              |
+  |                           |                                |              |
+  |                           | updatePayment(                 |              |
+  |                           |   AUTHORIZATION: FAILURE,      |              |
+  |                           |   CANCEL_AUTHORIZATION: SUCCESS)|             |
+  |                           |---------------------------------------------->|
+  |   { outcome: SUCCESS }    |                                |              |
+  |<--------------------------|                                |              |
+```
+
+---
+
+## Multi-Capture Sequence
+
+When `STRIPE_ENABLE_MULTI_OPERATIONS=true` and the merchant wants to capture in increments:
+
+```
+1. POST /payment-intents/:id { action: capturePayment, amount: 5000 }
+   → paymentIntents.capture(piId, { amount_to_capture: 5000, final_capture: false })
+   → CT: CHARGE SUCCESS, amount: 5000
+
+2. (later) POST /payment-intents/:id { action: capturePayment, amount: 3000 }
+   → paymentIntents.capture(piId, { amount_to_capture: 3000, final_capture: false })
+   → CT: CHARGE SUCCESS, amount: 3000
+   → charge.updated webhook arrives → processStripeEventMultipleCaptured() → CT updated with delta
+
+3. (final) POST /payment-intents/:id { action: capturePayment, amount: 2000 }
+   → paymentIntents.capture(piId, { amount_to_capture: 2000 })  ← no final_capture: false
+   → CT: CHARGE SUCCESS, amount: 2000
+```
+
+---
+
+## Decision Points
+
+| Point | Condition | Path |
+|---|---|---|
+| Amount provided | `amount < total` | Partial capture path — check multiOps flag |
+| Amount provided | `amount == total` or omitted | Full capture |
+| Multi-ops flag | `STRIPE_ENABLE_MULTI_OPERATIONS=true` | Allow partial capture |
+| Multi-ops flag | `STRIPE_ENABLE_MULTI_OPERATIONS=false` | Reject with 400 |
+| Capture method | `STRIPE_CAPTURE_METHOD=automatic` | Capture already happened — this call is invalid |
+
+---
+
+## Error Paths
+
+| Error | Cause | CT State |
+|---|---|---|
+| 400: partial capture rejected | Multi-ops disabled | CT unchanged |
+| Stripe capture fails | PI already captured/canceled | CT not updated |
+| Stripe cancel fails | PI already canceled or succeeded | CT not updated |
+| CT update fails | API error | Stripe updated but CT diverges |
+
+---
+
+## Note on Automatic Capture
+
+If `STRIPE_CAPTURE_METHOD=automatic` or `automatic_async`, the PI is charged at confirmation. Calling `capturePayment` in this case has no meaning and will fail at Stripe. The capture flow is only relevant for `manual` capture method.

--- a/context/workflows/process-express-checkout.md
+++ b/context/workflows/process-express-checkout.md
@@ -1,0 +1,298 @@
+# Workflow: Express Checkout (Apple Pay / Google Pay)
+
+**Trigger:** Storefront renders Express Checkout buttons (Apple Pay, Google Pay, etc.) before or during checkout.
+**Actors:** Browser (Enabler), Processor, Stripe API, CT API, Merchant storefront callbacks.
+**Outcome:** CT Payment in AUTHORIZED state, payment collected via native wallet UI.
+
+---
+
+## Initialization Paths
+
+Express Checkout has two initialization paths that differ in when the CT session is resolved:
+
+| Path | Class | Session at render time | Elements at render time | Customer binding on PI |
+| --- | --- | --- | --- | --- |
+| `_SetupExpress` (deferred) | `DropinExpressBuilder` | No — obtained in `onPayButtonClick` | No — created lazily inside `init()` | Never — one-shot PI |
+| `_Setup` (upfront) | `DropinExpressSetupBuilder` | Yes — passed to `createExpressBuilder()` | Yes — created in `getElements()` with `customerOptions` and `setupFutureUsage` | Yes, when CT customer has a Stripe ID |
+
+The two paths diverge at initialization and converge at `GET /payments` / `confirmPayment`.
+
+---
+
+## Flow — `_SetupExpress` (Deferred Session)
+
+```text
+Browser / Storefront        Enabler                 Processor              Stripe          CT
+  |                           |                         |                     |              |
+  | createExpressBuilder()    |                         |                     |              |
+  |-------------------------->|                         |                     |              |
+  |                           | POST /express-config    |                     |              |
+  |                           | (CORS, no session)      |                     |              |
+  |                           |------------------------>|                     |              |
+  |                           |  {publishableKey,       |                     |              |
+  |                           |   appearance,           |                     |              |
+  |                           |   expressOptions}       |                     |              |
+  |                           |<------------------------|                     |              |
+  |                           | Stripe.loadStripe()     |                     |              |
+  |                           | ExpressCheckoutElement  |                     |              |
+  |                           | .mount() (no Elements   |                     |              |
+  |                           |  instance yet — deferred)|                    |              |
+  |   Express buttons shown   |                         |                     |              |
+  |<--------------------------|                         |                     |              |
+  |                           |                         |                     |              |
+  | (user taps Apple Pay)     |                         |                     |              |
+  |-------------------------->|                         |                     |              |
+  |                           | onPayButtonClick()      |                     |              |
+  |                           |-- callback to merchant ->|                    |              |
+  |                           |                         | (merchant creates   |              |
+  |                           |                         |  session, returns   |              |
+  |                           |                         |  {sessionId})       |              |
+  |                           |<-- {sessionId} ---------|                     |              |
+  |                           | Creates Elements with   |                     |              |
+  |                           | sessionId now available |                     |              |
+  |                           |                         |                     |              |
+  |   Wallet sheet opens      |                         |                     |              |
+  |   (shows initial amount)  |                         |                     |              |
+  |                           |                         |                     |              |
+  | (user selects address)    |                         |                     |              |
+  |-------------------------->|                         |                     |              |
+  |                           | onShippingAddressSelected()                   |              |
+  |                           |-- callback to merchant ->|                    |              |
+  |                           |   (merchant updates     |                     |              |
+  |                           |    cart shipping addr)  |                     |              |
+  |                           |<-- updated totals -------|                    |              |
+  |                           | Stripe.updateWith()     |                     |              |
+  |   Wallet updates totals   |                         |                     |              |
+  |                           |                         |                     |              |
+  | (Stripe requests methods) |                         |                     |              |
+  |-------------------------->|                         |                     |              |
+  |                           | getShippingMethods()    |                     |              |
+  |                           |-- callback to merchant ->|                    |              |
+  |                           |<-- [{id, label, amount}]|                     |              |
+  |   Shipping options shown  |                         |                     |              |
+  |                           |                         |                     |              |
+  | (user selects method)     |                         |                     |              |
+  |-------------------------->|                         |                     |              |
+  |                           | onShippingMethodSelected()                    |              |
+  |                           |-- callback to merchant ->|                    |              |
+  |                           |<-- updated totals -------|                    |              |
+  |                           | Stripe.updateWith()     |                     |              |
+  |   Wallet updates total    |                         |                     |              |
+  |                           |                         |                     |              |
+  | (user authorizes payment) |                         |                     |              |
+  |-------------------------->|                         |                     |              |
+  |                           | onPaymentSubmit()       |                     |              |
+  |                           |-- callback to merchant  |                     |              |
+  |                           |   (final address,email) |                     |              |
+  |                           |<-- ok ------------------|                     |              |
+  |                           | GET /payments           |                     |              |
+  |                           | (x-express-checkout:true)                     |              |
+  |                           |------------------------>|                     |              |
+  |                           |                         | paymentIntents.create()            |
+  |                           |                         | (NO shipping params)|              |
+  |                           |                         |-------------------->|              |
+  |                           |                         | createPayment()     |              |
+  |                           |                         |------------------------------------------>|
+  |                           |                         | addPayment()        |              |
+  |                           |                         |------------------------------------------>|
+  |                           |  {clientSecret}         |                     |              |
+  |                           |<------------------------|                     |              |
+  |                           | stripe.confirmPayment() |                     |              |
+  |                           |------------------------>Stripe confirms PI --->|              |
+  |                           | POST /confirmPayments/:id                     |              |
+  |                           |------------------------>|                     |              |
+  |                           |                         | 4-point validation  |              |
+  |                           |                         | updatePayment(AUTHORIZED)          |
+  |                           |                         |------------------------------------------>|
+  |                           | onComplete()            |                     |              |
+  |   Wallet closes, success  |                         |                     |              |
+```
+
+---
+
+## Steps Detail
+
+### 1. Button Initialization (no session needed)
+
+- Enabler calls `POST /express-config` with CORS auth (no session header)
+- Receives publishable key, appearance, express element options
+- Loads Stripe SDK and mounts `ExpressCheckoutElement`
+- Elements instance creation is **deferred** until user taps a button
+
+### 2. Session Resolution (on wallet open)
+
+- User taps Apple Pay / Google Pay
+- `onPayButtonClick` callback is invoked on the merchant storefront
+- Merchant creates a session and returns `{ sessionId }`
+- Enabler creates the Stripe Elements instance with the session
+- Wallet sheet opens with `initialAmount` passed to the element
+
+### 3. Shipping Address Selection
+
+- User selects or confirms shipping address in wallet
+- `onShippingAddressSelected` callback fires with the address
+- Merchant updates cart with the new address and returns updated totals
+- Enabler calls `stripe.updateWith()` to refresh the wallet display
+
+### 4. Shipping Method Selection
+
+- Stripe wallet requests available shipping methods
+- `getShippingMethods` callback returns available methods with amounts
+- User selects a method
+- `onShippingMethodSelected` callback fires
+- Merchant updates cart; enabler updates wallet totals
+
+### 5. Payment Submission
+
+- User authorizes in wallet (Face ID, fingerprint, etc.)
+- `onPaymentSubmit` callback fires with final shipping address, billing address, customer email
+- Merchant updates cart with final data
+- Enabler calls `GET /payments` with `x-express-checkout: true` header
+- PI created **without** shipping params (wallet owns shipping)
+- Flow continues identical to standard payment from step 3 onward
+
+---
+
+## Flow — `_Setup` (Upfront Session)
+
+```text
+Browser / Storefront        Enabler                 Processor              Stripe          CT
+  |                           |                         |                     |              |
+  | createExpressBuilder()    |                         |                     |              |
+  | (sessionId provided)      |                         |                     |              |
+  |-------------------------->|                         |                     |              |
+  |                           | POST /express-config    |                     |              |
+  |                           | (CORS, no session)      |                     |              |
+  |                           |------------------------>|                     |              |
+  |                           |  {publishableKey,       |                     |              |
+  |                           |   appearance,           |                     |              |
+  |                           |   expressOptions}       |                     |              |
+  |                           |<------------------------|                     |              |
+  |                           | GET /customer/session   |                     |              |
+  |                           | (session auth)          |                     |              |
+  |                           |------------------------>|                     |              |
+  |                           |  {stripeCustomerId,     |                     |              |
+  |                           |   customerSessionSecret}|                     |              |
+  |                           |<------------------------|                     |              |
+  |                           | Stripe.loadStripe()     |                     |              |
+  |                           | getElements() with      |                     |              |
+  |                           | customerOptions +       |                     |              |
+  |                           | setupFutureUsage        |                     |              |
+  |                           | ExpressCheckoutElement  |                     |              |
+  |                           | .mount()                |                     |              |
+  |   Express buttons shown   |                         |                     |              |
+  |<--------------------------|                         |                     |              |
+  |                           |                         |                     |              |
+  | (user taps Apple Pay)     |                         |                     |              |
+  |-------------------------->|                         |                     |              |
+  |                           | onPayButtonClick()      |                     |              |
+  |                           |-- callback to merchant ->|                    |              |
+  |                           |   (session already      |                     |              |
+  |                           |    exists, return it)   |                     |              |
+  |                           |<-- {sessionId} ---------|                     |              |
+  |                           |                         |                     |              |
+  |   Wallet sheet opens      |                         |                     |              |
+  |                           |                         |                     |              |
+  | (user selects address,    |                         |                     |              |
+  |  method, authorizes)      |                         |                     |              |
+  |   [same as _SetupExpress] |                         |                     |              |
+  |                           |                         |                     |              |
+  |                           | GET /payments           |                     |              |
+  |                           | x-express-checkout: true|                     |              |
+  |                           | x-express-customer-     |                     |              |
+  |                           | session: true           |                     |              |
+  |                           |------------------------>|                     |              |
+  |                           |                         | paymentIntents.create()            |
+  |                           |                         | customer + setup_   |              |
+  |                           |                         | future_usage bound  |              |
+  |                           |                         | (expressWithCustomer|              |
+  |                           |                         |  = true)            |              |
+  |                           |                         |-------------------->|              |
+  |                           |                         | createPayment()     |              |
+  |                           |                         |------------------------------------------>|
+  |                           |                         | addPayment()        |              |
+  |                           |                         |------------------------------------------>|
+  |                           |  {clientSecret}         |                     |              |
+  |                           |<------------------------|                     |              |
+  |                           | stripe.confirmPayment() |                     |              |
+  |                           |------------------------>Stripe confirms PI --->|              |
+  |                           | POST /confirmPayments/:id                     |              |
+  |                           |------------------------>|                     |              |
+  |                           |                         | 4-point validation  |              |
+  |                           |                         | updatePayment(AUTHORIZED)          |
+  |                           |                         |------------------------------------------>|
+  |                           | onComplete()            |                     |              |
+  |   Wallet closes, success  |                         |                     |              |
+```
+
+---
+
+## Steps Detail — `_Setup` Path
+
+### 1. Button Initialization (session available)
+
+- Merchant passes `sessionId` to `createExpressBuilder()`
+- Enabler calls `POST /express-config` (CORS, no session) to get publishable key and options
+- Enabler calls `GET /customer/session` (with session auth) to resolve the Stripe customer; receives `stripeCustomerId` and `customerSessionClientSecret`
+- `baseOptions.stripeCustomerId` is set from the customer session response
+- Enabler calls `getElements()` — creates Stripe Elements with `customerOptions`, `setupFutureUsage`, and `customerSessionClientSecret`
+- `ExpressCheckoutElement` is mounted; buttons appear immediately
+
+### 2. Wallet Open
+
+- User taps Apple Pay / Google Pay
+- `onPayButtonClick` callback is invoked; merchant returns the existing `{ sessionId }` (already available)
+- Wallet sheet opens
+
+### 3–5. Shipping and Payment (identical to `_SetupExpress`)
+
+- Shipping address selection, method selection, and payment authorization follow the same callback sequence as the deferred path
+
+### 6. PI Creation with Customer Binding
+
+- Enabler calls `GET /payments` with both `x-express-checkout: true` and `x-express-customer-session: true` headers
+- Processor reads `x-express-customer-session: true` and sets `isExpressCustomerSession = true`
+- `expressWithCustomer = expressCheckout && Boolean(stripeCustomerId) && expressCustomerSession` evaluates to `true`
+- PI is created **with** `customer` and `setup_future_usage` — matching the Elements configuration
+- Flow continues identical to standard payment from confirmation onward
+
+---
+
+## Session Race Condition Handling
+
+The enabler tracks a `sessionInitGeneration` counter to handle the case where the user opens and dismisses the wallet quickly before `onPayButtonClick` resolves:
+
+- Each wallet open increments the generation counter
+- The Elements instance is only created if the generation matches when the callback resolves
+- Stale sessions from dismissed wallets are ignored
+
+---
+
+## Decision Points
+
+| Point | Condition | Path |
+| --- | --- | --- |
+| Session at render time | Session provided to `createExpressBuilder()` | `_Setup` path — Elements created upfront with customer |
+| Session at render time | No session provided | `_SetupExpress` path — Elements created lazily in `onPayButtonClick` |
+| `x-express-customer-session` header | `true` and `stripeCustomerId` resolved | PI bound with `customer` + `setup_future_usage` |
+| `x-express-customer-session` header | Absent or `stripeCustomerId` not resolved | One-shot PI, no customer binding |
+| Session availability (`_SetupExpress`) | `onPayButtonClick` returns `{sessionId}` | Create Elements, open wallet |
+| Session availability (`_SetupExpress`) | Callback times out or fails | Wallet fails to open; `onError` called |
+| Shipping address | Merchant returns updated totals | Wallet refreshes |
+| Shipping address | Merchant returns error | Wallet shows error; user cannot proceed |
+| Payment submit | Wallet authorization succeeds | Continue to PI creation |
+| Payment submit | Wallet authorization fails | `onError` called; PI never created |
+
+---
+
+## Error Paths
+
+| Error | Cause | CT State |
+| --- | --- | --- |
+| `/express-config` fails | Processor unavailable | Buttons not shown |
+| `GET /customer/session` fails (`_Setup`) | Processor error or no customer | `stripeCustomerId` absent; PI created without customer binding |
+| `onPayButtonClick` fails | Merchant callback error | Wallet never opens |
+| `onShippingAddressSelected` fails | Cart update error | Wallet shows error |
+| `GET /payments` fails | PI/CT creation error | No CT Payment created |
+| `confirmPayment` fails | `setup_future_usage` mismatch | Stripe rejects; no CT update |
+| Wallet authorization fails | Declined / user cancel | No CT Payment created |

--- a/context/workflows/process-refund-reversal.md
+++ b/context/workflows/process-refund-reversal.md
@@ -1,0 +1,130 @@
+# Workflow: Refund & Reversal
+
+**Trigger:** Merchant calls `POST /payment-intents/:id` with action `refundPayment` or `reversePayment`.
+**Actors:** Merchant backend / CT dashboard, Processor, Stripe API, CT API.
+**Outcome:** CT Payment updated with REFUND (refund) or CANCEL_AUTHORIZATION (reversal of authorization).
+
+---
+
+## Refund Flow
+
+```
+Merchant                  Processor                        Stripe          CT
+  |                           |                                |              |
+  | POST /payment-intents/:id |                                |              |
+  | { action: refundPayment,  |                                |              |
+  |   amount? }               |                                |              |
+  |-------------------------->|                                |              |
+  |                           | getPayment() from CT           |              |
+  |                           |---------------------------------------------->|
+  |                           |                                |              |
+  |                           | hasTransactionInState(         |              |
+  |                           |   payment, 'Refund', ['Success']) (CT-side)   |
+  |                           |                                |              |
+  |                           | if existing CT Refund &&       |              |
+  |                           |   !stripeEnableMultiOps:       |              |
+  |                           |   → log warning (but continue) |              |
+  |                           |                                |              |
+  |                           | refunds.create(                |              |
+  |                           |   { payment_intent: piId,      |              |
+  |                           |     amount? })                 |              |
+  |                           |-------------------------------->|              |
+  |                           |                                |              |
+  |                           | updatePayment(                 |              |
+  |                           |   REFUND: RECEIVED)            |              |
+  |                           |---------------------------------------------->|
+  |   { outcome: RECEIVED }   |                                |              |
+  |<--------------------------|                                |              |
+  |                           |                                |              |
+  |             (async — minutes later)                        |              |
+  |                           |                                |              |
+  | POST /stripe/webhooks     |                                |              |
+  | charge.refunded           |                                |              |
+  |<----------------------------------------------------------Stripe           |
+  |                           | processStripeEventRefunded()   |              |
+  |                           | or processStripeEvent()        |              |
+  |                           | updatePayment(REFUND: SUCCESS) |              |
+  |                           |---------------------------------------------->|
+```
+
+---
+
+## Reversal Flow (Auto-Detect)
+
+```
+Merchant                  Processor                                        CT
+  |                           |                                              |
+  | POST /payment-intents/:id |                                              |
+  | { action: reversePayment }|                                              |
+  |-------------------------->|                                              |
+  |                           | getPayment() from CT                         |
+  |                           |--------------------------------------------->|
+  |                           |                                              |
+  |                           | Check CT transactions:                       |
+  |                           |                                              |
+  |                           | CASE A: CHARGE SUCCESS exists                |
+  |                           |   && no REFUND/CANCEL_AUTHORIZATION yet      |
+  |                           |   → refundPayment() (see refund flow above)  |
+  |                           |                                              |
+  |                           | CASE B: AUTHORIZATION SUCCESS exists         |
+  |                           |   && no REFUND/CANCEL_AUTHORIZATION yet      |
+  |                           |   → cancelPayment() (see capture/cancel flow)|
+  |                           |                                              |
+  |                           | CASE C: neither applies                      |
+  |                           |   → throw error                              |
+```
+
+---
+
+## Refund State Machine
+
+```
+CT REFUND transaction states:
+
+  [Refund created]
+       ↓
+  RECEIVED  ← set synchronously when refunds.create() succeeds
+       ↓
+  SUCCESS   ← set when charge.refunded webhook arrives
+```
+
+The RECEIVED → SUCCESS transition always happens via webhook. It is never set synchronously.
+
+---
+
+## Decision Points
+
+| Point | Condition | Path |
+|---|---|---|
+| Existing refunds | Refunds exist AND multi-ops disabled | Log warning; continue (not blocked) |
+| Existing refunds | Refunds exist AND multi-ops enabled | Normal multi-refund path |
+| Amount | Partial amount provided | Partial refund |
+| Amount | No amount | Full refund of remaining amount |
+| `reversePayment` | CHARGE transaction exists | Route to `refundPayment()` |
+| `reversePayment` | AUTHORIZATION transaction exists (no charge) | Route to `cancelPayment()` |
+| `reversePayment` | Payment already reversed | Throw error |
+
+---
+
+## Webhook Handling for Refunds
+
+### Standard path (`STRIPE_ENABLE_MULTI_OPERATIONS=false`)
+- `charge.refunded` → `processStripeEvent()` → converter creates REFUND:SUCCESS + CHARGE_BACK:SUCCESS
+- Amount taken from `charge.amount_refunded` (cumulative)
+
+### Multi-operations path (`STRIPE_ENABLE_MULTI_OPERATIONS=true`)
+- `charge.refunded` → `processStripeEventRefunded()` → fetches specific refund object from Stripe
+- Amount taken from the individual refund object (not cumulative)
+- Allows multiple CT REFUND transactions on the same payment
+
+---
+
+## Error Paths
+
+| Error | Cause | CT State |
+|---|---|---|
+| Stripe refund fails | PI not yet captured (only authorized) | CT stays at RECEIVED or unchanged |
+| Stripe refund fails | Refund amount exceeds charged amount | CT not updated |
+| Webhook never arrives | Stripe delivery failure | CT stuck at RECEIVED indefinitely |
+| `reversePayment` with no valid state | Payment already reversed or canceled | Error returned; CT unchanged |
+| CT update fails | API error | Stripe refund processed but CT not updated |

--- a/context/workflows/process-standard-payment.md
+++ b/context/workflows/process-standard-payment.md
@@ -1,0 +1,148 @@
+# Workflow: Standard Embedded Payment
+
+**Trigger:** Customer reaches checkout and mounts the Stripe Payment Element.
+**Actors:** Browser (Enabler), Processor, Stripe API, CT API.
+**Outcome:** CT Payment in AUTHORIZED state, Stripe PI in `succeeded` or `requires_capture` state.
+
+---
+
+## Flow
+
+```text
+Browser                    Enabler                 Processor               Stripe          CT
+  |                          |                         |                      |              |
+  | createDropinBuilder()    |                         |                      |              |
+  |------------------------->|                         |                      |              |
+  |                          | GET /config-element     |                      |              |
+  |                          |------------------------>|                      |              |
+  |                          |  appearance, layout,    |                      |              |
+  |                          |  captureMethod          |                      |              |
+  |                          |<------------------------|                      |              |
+  |                          | GET /customer/session   |                      |              |
+  |                          |------------------------>|                      |              |
+  |                          |                         | retrieve/create      |              |
+  |                          |                         | Stripe customer ----->|              |
+  |                          |                         | create ephemeralKey ->|              |
+  |                          |                         | create customerSession>|             |
+  |                          |                         | save customerId ----->|              |
+  |                          |  {stripeCustomerId,     |<--------------------- |              |
+  |                          |   ephemeralKey,         |                      |              |
+  |                          |   sessionId}            |                      |              |
+  |                          |<------------------------|                      |              |
+  |                          | Stripe.loadStripe()     |                      |              |
+  |                          | elements.create()       |                      |              |
+  |                          | paymentElement.mount()  |                      |              |
+  |   Payment Element shown  |                         |                      |              |
+  |<-------------------------|                         |                      |              |
+  |                          |                         |                      |              |
+  | (user fills card data)   |                         |                      |              |
+  |                          |                         |                      |              |
+  | click Pay button         |                         |                      |              |
+  |------------------------->|                         |                      |              |
+  |                          | elements.submit()       |                      |              |
+  |                          | (validates form)        |                      |              |
+  |                          | GET /payments           |                      |              |
+  |                          |------------------------>|                      |              |
+  |                          |                         | getCart()            |              |
+  |                          |                         |---------------------------------------------->|
+  |                          |                         | paymentIntents.create()               |       |
+  |                          |                         |---------------------->|               |       |
+  |                          |                         | paymentIntents.update() (metadata)    |       |
+  |                          |                         |---------------------->|               |       |
+  |                          |                         | createPayment()       |               |       |
+  |                          |                         |---------------------------------------------->|
+  |                          |                         | addPayment(cart)      |               |       |
+  |                          |                         |---------------------------------------------->|
+  |                          |  {clientSecret}         |                      |              |
+  |                          |<------------------------|                      |              |
+  |                          | stripe.confirmPayment() |                      |              |
+  |                          |   (handles 3DS if needed, see 3DS note)        |              |
+  |                          |------------------------>Stripe confirms PI ---->|              |
+  |                          |                         |                      |              |
+  |                          | POST /confirmPayments/:id                      |              |
+  |                          |------------------------>|                      |              |
+  |                          |                         | paymentIntents.retrieve()            |
+  |                          |                         |---------------------->|              |
+  |                          |                         | 4-point validation    |              |
+  |                          |                         | updatePayment(AUTHORIZED)            |
+  |                          |                         |---------------------------------------------->|
+  |                          |  {success}              |                      |              |
+  |                          |<------------------------|                      |              |
+  | onComplete({isSuccess})  |                         |                      |              |
+  |<-------------------------|                         |                      |              |
+```
+
+---
+
+## Steps Detail
+
+### 1. Initialization
+
+- Enabler fetches config from `/config-element` (appearance, layout, capture method, billing address setting)
+- If cart has `customerId`: fetches customer session from `/customer/session` (enables saved payment methods)
+- Stripe Elements created with customer data and appearance config
+
+### 2. Payment Intent Creation (`GET /payments`)
+
+- Processor reads cart from CT to get amount and currency
+- Creates Stripe PI with: amount, currency, capture method, customer (if any), setup_future_usage (if configured), tax hooks (if applicable)
+- Makes a **second Stripe call** (`paymentIntents.update()`) to write `ct_payment_id` into the PI's metadata — the PI is created first, then the metadata is patched separately. If this second call fails, the CT Payment exists but the PI has no `ct_payment_id` in metadata; webhook events for that PI will be silently skipped
+- Creates CT Payment object with PENDING AUTHORIZATION transaction
+- Associates CT Payment to cart via `addPayment()`
+- Returns `clientSecret` to enabler
+
+### 3. Stripe Confirmation (`stripe.confirmPayment()`)
+
+- Enabler calls Stripe JS SDK to confirm the PI
+- Stripe handles: 3DS authentication, redirect-based methods, card validation
+- On success: PI moves to `succeeded` (automatic capture) or `requires_capture` (manual)
+- On failure: Stripe returns error; `onError` callback is invoked
+
+### 4. Backend Confirmation (`POST /confirmPayments/:id`)
+
+- Enabler sends PI ID to processor
+- Processor retrieves PI from Stripe
+- Runs 4-point validation (see `business-rules/payment-lifecycle.md` Rule 2)
+- Updates CT Payment: AUTHORIZATION → SUCCESS (or CHARGE → SUCCESS for automatic capture)
+- Returns success to enabler
+
+### 5. Async Webhook (parallel path)
+
+- Stripe sends `payment_intent.succeeded` or `charge.succeeded` webhook
+- Processor records additional transaction data in CT (CHARGE:SUCCESS or AUTHORIZATION:SUCCESS)
+- Stores payment method if customer opted in; creates recurring job if applicable
+
+---
+
+## Decision Points
+
+| Point | Condition | Path |
+|---|---|---|
+| Customer session | `cart.customerId` exists | Fetch session → enable saved methods |
+| Customer session | No `customerId` (guest) | Skip session → no saved methods |
+| 4-point validation | All checks pass | Update CT to AUTHORIZED |
+| 4-point validation | Any check fails | Return 400; CT stays in PENDING |
+| 3DS required | Stripe returns `requires_action` | Redirect user; resume after authentication |
+
+---
+
+## 3DS / Redirect Note
+
+`stripe.confirmPayment()` handles 3DS transparently. If the card requires authentication:
+
+1. Stripe redirects the user to the bank's 3DS page (or shows an embedded modal)
+2. After authentication, Stripe redirects back to `MERCHANT_RETURN_URL`
+3. The storefront must call `POST /confirmPayments/:id` again after the redirect
+4. The backend validates the now-succeeded PI and updates CT
+
+---
+
+## Error Paths
+
+| Error | Cause | CT State |
+|---|---|---|
+| Elements validation fails | Invalid card data | No PI created; CT unchanged |
+| `/payments` returns error | CT or Stripe API failure | No PI created; CT unchanged |
+| PI metadata update fails | Stripe API error after PI creation | PI created but `ct_payment_id` missing; webhook events skipped |
+| `stripe.confirmPayment()` fails | Card declined, 3DS failed | PI created in Stripe; CT has PENDING AUTHORIZATION (orphaned) |
+| `/confirmPayments/:id` validation fails | PI/CT mismatch | CT stays PENDING; PI succeeded in Stripe (orphaned) |

--- a/context/workflows/process-webhook.md
+++ b/context/workflows/process-webhook.md
@@ -1,0 +1,151 @@
+# Workflow: Webhook Processing
+
+**Trigger:** Stripe sends an event to `POST /stripe/webhooks`.
+**Actors:** Stripe (sender), Processor, CT API.
+**Outcome:** CT Payment updated with the correct transaction state reflecting Stripe's event.
+
+---
+
+## Flow
+
+```
+Stripe                    Processor                               CT
+  |                           |                                    |
+  | POST /stripe/webhooks     |                                    |
+  | (Stripe-Signature header) |                                    |
+  |-------------------------->|                                    |
+  |                           | webhooks.constructEvent()          |
+  |                           | (verify signature)                 |
+  |                           |                                    |
+  |                           | if signature invalid → 400        |
+  |                           |                                    |
+  |                           | (process event based on type)      |
+  |                           |                                    |
+  |                           |--- payment_intent.succeeded -----> |
+  |                           |    charge.succeeded                |
+  |                           |    → processStripeEvent()          |
+  |                           |    → updatePayment(CHARGE:SUCCESS  |
+  |                           |       or AUTHORIZATION:SUCCESS)    |
+  |                           |    → storePaymentMethod()          |
+  |                           |    → savePaymentMethodIfNew()  --->|
+  |                           |    → createRecurringPaymentJob() ->|
+  |                           |                                    |
+  |                           |--- payment_intent.canceled ------> |
+  |                           |    → processStripeEvent()          |
+  |                           |    → updatePayment(AUTHORIZATION:FAILURE
+  |                           |       + CANCEL_AUTHORIZATION:SUCCESS)
+  |                           |                                    |
+  |                           |--- payment_intent.payment_failed ->|
+  |                           |    → processStripeEvent()          |
+  |                           |    → updatePayment(AUTHORIZATION:FAILURE)
+  |                           |                                    |
+  |                           |--- payment_intent.requires_action  |
+  |                           |    → processStripeEvent()          |
+  |                           |    → converter: no case found      |
+  |                           |    → error swallowed; CT not updated
+  |                           |                                    |
+  |                           |--- charge.refunded --------------> |
+  |                           |    if multiOps:                    |
+  |                           |      → processStripeEventRefunded()|
+  |                           |      → refunds.list() [Stripe]     |
+  |                           |      → updatePayment(REFUND:SUCCESS)|
+  |                           |    else:                           |
+  |                           |      → processStripeEvent()        |
+  |                           |      → updatePayment(REFUND:SUCCESS|
+  |                           |         + CHARGE_BACK:SUCCESS)     |
+  |                           |                                    |
+  |                           |--- charge.updated (multicapture) ->|
+  |                           |    if multiOps:                    |
+  |                           |      → processStripeEventMultipleCaptured()
+  |                           |      → reads previous_attributes   |
+  |                           |      → compute delta amount        |
+  |                           |      → updatePayment(CHARGE:SUCCESS)|
+  |                           |                                    |
+  |   200 OK                  |                                    |
+  |<--------------------------|                                    |
+```
+
+---
+
+## Steps Detail
+
+### 1. Signature Verification
+
+- The pre-handler (`StripeHeaderAuthHook.authenticate`) only checks that the `stripe-signature` header is present.
+- Inside the handler, the raw request body is passed to `stripeApi().webhooks.constructEvent()` with `STRIPE_WEBHOOK_SIGNING_SECRET`.
+- If verification fails: respond 400, stop processing.
+- If verification passes: process the event synchronously (`await`-ed), then respond 200. The handler does NOT ack early. See `business-rules/webhook-handling.md` Rule 2 for the limitation.
+
+### 2. Event Routing
+
+Events are routed to handlers based on type:
+
+| Event | Handler | Additional Action | Notes |
+|---|---|---|---|
+| `payment_intent.succeeded` | `processStripeEvent()` | `storePaymentMethod()` | Converter emits `CHARGE: SUCCESS` |
+| `charge.succeeded` | `processStripeEvent()` | `storePaymentMethod()` | Converter emits `AUTHORIZATION: SUCCESS` |
+| `payment_intent.canceled` | `processStripeEvent()` | — | `AUTHORIZATION: FAILURE + CANCEL_AUTHORIZATION: SUCCESS` |
+| `payment_intent.requires_action` | `processStripeEvent()` | — | Converter has no case → `Unsupported event` thrown and swallowed; CT not updated |
+| `payment_intent.payment_failed` | `processStripeEvent()` | — | `AUTHORIZATION: FAILURE` |
+| `charge.refunded` | `processStripeEventRefunded()` (multi-ops) or `processStripeEvent()` | — | Multi-ops uses per-refund amount via `refunds.list` |
+| `charge.updated` | `processStripeEventMultipleCaptured()` (multi-ops only) | — | Skipped entirely when multi-ops disabled |
+
+### 3. CT Payment ID Extraction
+- `stripeEventConverter.getCtPaymentId()` reads `event.data.object.metadata.ct_payment_id`
+- If missing: cannot update CT — logs error and skips
+
+### 4. Transaction Mapping
+- `stripeEventConverter.convert()` maps the event to CT transaction format:
+  - Determines transaction types and states
+  - Extracts PSP reference (charge ID or PI ID)
+  - Extracts amount from appropriate field per event type
+  - Extracts payment method type
+
+### 5. CT Payment Update
+- `ctPaymentService.updatePayment()` applies the transactions
+- Does **not** automatically retry on `409 ConcurrentModification` — the Connect Payments SDK throws on version conflict; the connector logs the error and the transaction update is lost. See `business-rules/payment-lifecycle.md` Rule 4.
+
+### 6. Payment Method Storage (for `payment_intent.succeeded` and `charge.succeeded` only)
+
+The dispatcher in `processor/src/routes/stripe-payment.route.ts` calls `storePaymentMethod(event)` after `processStripeEvent(event)` for both events.
+
+- `extractPaymentMethodDataFromEvent()` extracts the Stripe payment method ID, CT customer ID, and CT payment ID from event metadata.
+- `savePaymentMethodIfNew()` calls `ctPaymentMethodService.getByTokenValue({ customerId, paymentInterface, tokenValue })` and skips the save if the token already exists.
+- If new: retrieves the full payment method from Stripe (`paymentMethods.retrieve`), then `ctPaymentMethodService.save({ customerId, paymentInterface, token, method })`.
+- `updatePaymentWithToken()` writes `paymentMethodInfo.token.value` on the CT payment.
+- `ctRecurringPaymentJobService.createRecurringPaymentJobIfApplicable()` is called only when `ctPaymentId` is present in the event metadata. If `ctPaymentId` is missing, the recurring job step is silently skipped (no error thrown).
+
+---
+
+## Multi-Capture Webhook Detail
+
+When `charge.updated` arrives and `STRIPE_ENABLE_MULTI_OPERATIONS=true`, `processStripeEventMultipleCaptured()`:
+
+1. Reads `event.data.previous_attributes.amount_captured` and `charge.amount_captured`.
+2. Skips processing if `charge.captured === true` or if the captured amount did not increase since `previous_attributes`.
+3. Computes delta: `charge.amount_captured - previous.amount_captured`.
+4. Sets `interactionId` and `pspReference` to `charge.balance_transaction`.
+5. Calls `ctPaymentService.updatePayment` to record a `CHARGE: SUCCESS` transaction with the delta as the amount.
+
+There is also a parallel path in `processStripeEvent()` that calls `balanceTransactions.list({ source: latest_charge, limit: 10 })` when all three guards pass: `capture_method === 'manual'`, `payment_method_options.card.request_multicapture === 'if_available'`, and `latest_charge` is a non-empty string. If the result contains more than one balance transaction, `interactionId` and `amount` are overridden from `balanceTransactions.data[0]`.
+
+---
+
+## Idempotency Behavior
+
+- Webhook events can be delivered more than once (Stripe at-least-once guarantee)
+- Payment method storage is idempotent: checks existing token before save
+- CT transaction creation is **not** natively idempotent — duplicate webhooks can create duplicate CT transactions
+- Stripe deduplicates events at the source but retries on non-200 responses — always return 200 quickly to prevent retries
+
+---
+
+## Error Paths
+
+| Error | Cause | Behavior |
+|---|---|---|
+| Signature verification fails | Wrong secret or tampered payload | 400 response; Stripe retries |
+| `ct_payment_id` missing from metadata | PI created without metadata | Logs error; CT not updated |
+| CT update fails (version conflict) | Concurrent update | SDK throws; connector logs error and continues — transaction update is lost |
+| CT update fails (other) | CT API error | Transaction lost; CT diverges from Stripe |
+| Stripe refunds.list() fails | Stripe API error | Refund transaction not recorded in CT |

--- a/enabler/index.html
+++ b/enabler/index.html
@@ -142,7 +142,7 @@
               }
             }
 
-            const sessionId = isExpress ? '' : (await getSessionId(cartId));
+            const sessionId = await getSessionId(cartId);
 
             const enabler = new Enabler({
               processorUrl: __VITE_PROCESSOR_URL__,

--- a/enabler/package-lock.json
+++ b/enabler/package-lock.json
@@ -3378,9 +3378,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4196,7 +4196,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -7681,9 +7682,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/enabler/src/express/dropin-express.ts
+++ b/enabler/src/express/dropin-express.ts
@@ -559,7 +559,8 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
   /**
    * Builds headers for enabler → processor requests.
    *
-   * @returns Headers including `Content-Type`, `x-session-id` (`currentSessionId`), and optional `x-express-checkout`.
+   * @returns Headers including `Content-Type`, `x-session-id` (`currentSessionId`), `x-express-checkout`,
+   * and `x-express-customer-session` when the _Setup path resolved a Stripe customer (Elements has setupFutureUsage).
    */
   private getHeadersConfig(): HeadersInit {
     const headers: Record<string, string> = {
@@ -568,6 +569,9 @@ export class StripeExpressComponent extends DefaultExpressComponent implements E
     };
     if (this.baseOptions.expressCheckout) {
       headers['x-express-checkout'] = 'true';
+    }
+    if (this.baseOptions.stripeCustomerId) {
+      headers['x-express-customer-session'] = 'true';
     }
     return headers;
   }

--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -1146,6 +1146,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4023,9 +4024,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4645,6 +4646,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5545,6 +5547,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@fastify/merge-json-schemas": "^0.2.0",
         "ajv": "^8.12.0",
@@ -5604,7 +5607,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
       "version": "5.8.5",
@@ -8761,6 +8765,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -11651,9 +11656,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/processor/src/routes/stripe-payment.route.ts
+++ b/processor/src/routes/stripe-payment.route.ts
@@ -84,7 +84,9 @@ export const paymentRoutes = async (fastify: FastifyInstance, opts: FastifyPlugi
       const isExpressCheckout =
         request.headers['x-express-checkout'] === 'true' ||
         request.headers['x-express-checkout'] === '1';
-      const resp = await opts.paymentService.createPaymentIntentStripe(isExpressCheckout);
+      const isExpressCustomerSession =
+        request.headers['x-express-customer-session'] === 'true';
+      const resp = await opts.paymentService.createPaymentIntentStripe(isExpressCheckout, isExpressCustomerSession);
       return reply.status(200).send(resp);
     },
   );

--- a/processor/src/server/server.ts
+++ b/processor/src/server/server.ts
@@ -38,7 +38,7 @@ export const setupFastify = async () => {
 
   // Enable CORS
   await server.register(cors, {
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Correlation-ID', 'X-Request-ID', 'X-Session-ID', 'x-express-checkout'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Correlation-ID', 'X-Request-ID', 'X-Session-ID', 'x-express-checkout', 'x-express-customer-session'],
     origin: '*',
   });
 

--- a/processor/src/services/stripe-payment.service.ts
+++ b/processor/src/services/stripe-payment.service.ts
@@ -475,7 +475,7 @@ export class StripePaymentService extends AbstractPaymentService {
    * @param expressCheckout When true, shipping is omitted on the PaymentIntent so the Express Checkout Element can set it at confirm (default false).
    * @return Promise<PaymentResponseSchemaDTO> A Promise that resolves to a PaymentResponseSchemaDTO object containing the client secret and payment reference.
    */
-  public async createPaymentIntentStripe(expressCheckout = false): Promise<PaymentResponseSchemaDTO> {
+  public async createPaymentIntentStripe(expressCheckout = false, expressCustomerSession = false): Promise<PaymentResponseSchemaDTO> {
     const config = getConfig();
     const ctCart = await this.ctCartService.getCart({ id: getCartIdFromContext() });
     const customer = await this.getCtCustomer(ctCart.customerId!);
@@ -485,6 +485,11 @@ export class StripePaymentService extends AbstractPaymentService {
     const merchantReturnUrl = getMerchantReturnUrlFromContext() || config.merchantReturnUrl;
     const setupFutureUsage = this.getPaymentIntentSetupFutureUsage(ctCart);
     const stripeCustomerId = customer?.custom?.fields?.[stripeCustomerIdFieldName];
+    // expressWithCustomer: true only when the enabler used _Setup (session at render time) AND resolved
+    // a Stripe customer — meaning Elements was created with setupFutureUsage and customerOptions.
+    // expressCustomerSession signals this from the enabler via x-express-customer-session header.
+    // _SetupExpress (deferred) never sets this header, so setup_future_usage stays off for that path.
+    const expressWithCustomer = expressCheckout && Boolean(stripeCustomerId) && expressCustomerSession;
 
     // Tax calculation integration
     const taxCalculationReferences = ctCart.custom?.fields?.[CT_CUSTOM_FIELD_TAX_CALCULATIONS] as string[] | undefined;
@@ -500,6 +505,7 @@ export class StripePaymentService extends AbstractPaymentService {
         ctCart,
         amountPlanned,
         expressCheckout,
+        expressWithCustomer,
         shippingAddress,
         stripeCustomerId,
         setupFutureUsage,
@@ -616,6 +622,7 @@ export class StripePaymentService extends AbstractPaymentService {
     ctCart: Cart;
     amountPlanned: { centAmount: number; currencyCode: string };
     expressCheckout: boolean;
+    expressWithCustomer: boolean;
     shippingAddress: Stripe.PaymentIntentCreateParams.Shipping | null | undefined;
     stripeCustomerId: string | undefined;
     setupFutureUsage: Stripe.PaymentIntentCreateParams.SetupFutureUsage | undefined;
@@ -629,6 +636,7 @@ export class StripePaymentService extends AbstractPaymentService {
       ctCart,
       amountPlanned,
       expressCheckout,
+      expressWithCustomer,
       shippingAddress,
       stripeCustomerId,
       setupFutureUsage,
@@ -640,8 +648,9 @@ export class StripePaymentService extends AbstractPaymentService {
     } = params;
 
     return {
-      // Express Checkout uses one-shot payment: no customer/setup_future_usage so the PI matches frontend Elements (created without them).
-      ...(!expressCheckout && stripeCustomerId && {
+      // Standard and express-with-known-customer paths both bind customer and setup_future_usage.
+      // Express-without-customer (deferred session path) is one-shot: no customer binding.
+      ...((!expressCheckout || expressWithCustomer) && stripeCustomerId && {
         customer: stripeCustomerId,
         ...(setupFutureUsage && { setup_future_usage: setupFutureUsage }),
       }),

--- a/processor/test/routes.test/stripe-payment.spec.ts
+++ b/processor/test/routes.test/stripe-payment.spec.ts
@@ -525,7 +525,7 @@ describe('Stripe Payment APIs', () => {
         },
       });
 
-      expect(spiedPaymentService.createPaymentIntentStripe).toHaveBeenCalledWith(true);
+      expect(spiedPaymentService.createPaymentIntentStripe).toHaveBeenCalledWith(true, false);
     });
   });
 

--- a/processor/test/services/stripe-payment.service.spec.ts
+++ b/processor/test/services/stripe-payment.service.spec.ts
@@ -45,6 +45,7 @@ import { ClientResponse } from '@commercetools/platform-sdk/dist/declarations/sr
 import {
   mockCreateSessionResult,
   mockCtCustomerData,
+  mockCtCustomerWithoutCustomFieldsData,
   mockCtCustomerId,
   mockCustomerData,
   mockEphemeralKeyResult,
@@ -760,7 +761,7 @@ describe('stripe-payment.service', () => {
       expect(updatePaymentMock).toHaveBeenCalledTimes(0);
     });
 
-    test('should create PaymentIntent without shipping and without customer/setup_future_usage when expressCheckout is true', async () => {
+    test('should create PaymentIntent without shipping but with customer when expressCheckout is true and expressCustomerSession is true', async () => {
       jest
         .spyOn(DefaultCartService.prototype, 'getCart')
         .mockReturnValue(Promise.resolve(mockGetCartResult()));
@@ -772,7 +773,46 @@ describe('stripe-payment.service', () => {
       jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(mockGetPaymentResult);
       jest.spyOn(DefaultCartService.prototype, 'addPayment').mockResolvedValue(mockGetCartResult());
 
-      await stripePaymentService.createPaymentIntentStripe(true);
+      await stripePaymentService.createPaymentIntentStripe(true, true);
+
+      const createArgs = createSpy.mock.calls[0][0];
+      expect(createArgs).not.toHaveProperty('shipping');
+      expect(createArgs).toHaveProperty('customer', mockStripeCustomerId);
+    });
+
+    test('should create PaymentIntent without shipping and without customer when expressCheckout is true but expressCustomerSession is false (_SetupExpress path)', async () => {
+      jest
+        .spyOn(DefaultCartService.prototype, 'getCart')
+        .mockReturnValue(Promise.resolve(mockGetCartResult()));
+      jest.spyOn(StripePaymentService.prototype, 'getCtCustomer').mockResolvedValue(mockCtCustomerData);
+      jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue(mockGetPaymentAmount);
+      const createSpy = jest
+        .spyOn(Stripe.prototype.paymentIntents, 'create')
+        .mockReturnValue(Promise.resolve(mockStripeCreatePaymentResult));
+      jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(mockGetPaymentResult);
+      jest.spyOn(DefaultCartService.prototype, 'addPayment').mockResolvedValue(mockGetCartResult());
+
+      await stripePaymentService.createPaymentIntentStripe(true, false);
+
+      const createArgs = createSpy.mock.calls[0][0];
+      expect(createArgs).not.toHaveProperty('shipping');
+      expect(createArgs).not.toHaveProperty('customer');
+      expect(createArgs).not.toHaveProperty('setup_future_usage');
+    });
+
+    test('should create PaymentIntent without shipping and without customer when expressCheckout is true and no customer fields exist', async () => {
+      jest
+        .spyOn(DefaultCartService.prototype, 'getCart')
+        .mockReturnValue(Promise.resolve(mockGetCartResult()));
+      jest.spyOn(StripePaymentService.prototype, 'getCtCustomer').mockResolvedValue(mockCtCustomerWithoutCustomFieldsData);
+      jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue(mockGetPaymentAmount);
+      const createSpy = jest
+        .spyOn(Stripe.prototype.paymentIntents, 'create')
+        .mockReturnValue(Promise.resolve(mockStripeCreatePaymentResult));
+      jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(mockGetPaymentResult);
+      jest.spyOn(DefaultCartService.prototype, 'addPayment').mockResolvedValue(mockGetCartResult());
+
+      await stripePaymentService.createPaymentIntentStripe(true, true);
 
       const createArgs = createSpy.mock.calls[0][0];
       expect(createArgs).not.toHaveProperty('shipping');


### PR DESCRIPTION
When Express Checkout is initialized with a CT session at render time (_Setup path), the enabler now sends `x-express-customer-session: true` on GET /payments. The processor uses this flag to bind `customer` and `setup_future_usage` on the PaymentIntent, matching the Stripe Elements instance created with `customerOptions` and `setupFutureUsage`.

The _SetupExpress (deferred) path is unaffected — PaymentIntents on that path remain one-shot with no customer binding, preserving the existing behavior.

Changes:
- enabler: send `x-express-customer-session: true` when stripeCustomerId is present in baseOptions
- enabler: always resolve sessionId (remove the express-only skip)
- processor route: read and forward new header as `expressCustomerSession`
- processor service: derive `expressWithCustomer` flag and apply customer binding conditionally
- server: add `x-express-customer-session` to CORS allowedHeaders
- tests: update and expand unit tests for all three express paths
- .gitignore: add coverage/ and dist/ entries
- lockfiles: bump brace-expansion 5.0.5→5.0.6 and ws 8.18.3→8.20.1