### PR TITLE
fix(enabler): apply expressElementOptions in mock payment enabler

### DIFF
--- a/enabler/package-lock.json
+++ b/enabler/package-lock.json
@@ -7682,9 +7682,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/enabler/src/payment-enabler/payment-enabler-mock.ts
+++ b/enabler/src/payment-enabler/payment-enabler-mock.ts
@@ -123,7 +123,14 @@ export class MockPaymentEnabler implements PaymentEnabler {
         onError: options.onError || (() => {}),
         paymentElement: elements.create('payment', elementsOptions as StripePaymentElementOptions ),// MVP this could be expressCheckout or payment for subscritpion.
         elements: elements,
-        ...(customer && {stripeCustomerId: customer?.stripeCustomerId,})
+        ...(customer && {stripeCustomerId: customer?.stripeCustomerId,}),
+        ...(configEnvResponse.expressElementOptions && (() => {
+          const raw = parseJSON<Record<string, unknown>>(configEnvResponse.expressElementOptions!);
+          const expressElementOptions = Object.fromEntries(
+            ALLOWED_EXPRESS_OPTION_KEYS.filter((k) => raw[k] !== undefined).map((k) => [k, raw[k]]),
+          ) as ExpressElementOptions;
+          return { expressElementOptions };
+        })()),
       },
     });
   };

--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -9924,9 +9924,10 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -11656,9 +11657,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
The mock enabler was not forwarding STRIPE_EXPRESS_ELEMENT_OPTIONS to the builder, causing it to diverge from the real enabler's behavior. Applies the same ALLOWED_EXPRESS_OPTION_KEYS filtering already used by the live path.

Also updates transitive deps: ws 8.20.1→8.21.0, qs 6.14.2→6.15.2.