### PR TITLE
docs(context): fix inaccurate API paths and function reference in known-issues

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -98,8 +98,8 @@ loadStripe(publishableKey)
 
 | Method | Endpoint | Header | Purpose |
 | --- | --- | --- | --- |
-| `GET` | `/config-element/payment` | `x-session-id` | Appearance, layout, captureMethod, setupFutureUsage, cartInfo |
-| `GET` | `/operations/config` | `x-session-id` | publishableKey, environment |
+| `GET` | `/config-element/:paymentComponent` | `x-session-id` | Appearance, layout, captureMethod, setupFutureUsage, cartInfo (enabler substitutes `payment` for `:paymentComponent`) |
+| `GET` | `/operations/config` | `x-session-id` | publishableKey, environment (bare route `/config` in `operation.route.ts`; full path includes the `/operations` prefix from `operation.plugin.ts:8`) |
 | `GET` | `/customer/session` | `x-session-id` | stripeCustomerId, ephemeralKey, sessionId (204 = guest) |
 | `POST` | `/express-config` | none (CORS) | publishableKey, captureMethod, appearance, expressElementOptions |
 | `GET` | `/payments` | `x-session-id`, `x-express-checkout: true` (express only) | Creates PI + CT Payment; returns clientSecret |
@@ -122,6 +122,8 @@ loadStripe(publishableKey)
 | `POST /stripe/webhooks` | Stripe Signature | Receives and processes Stripe events. Pre-handler hook checks `stripe-signature` header presence; full signature verification (`stripe.webhooks.constructEvent`) happens inside the handler. Event processing runs synchronously and the handler returns 200 after processing completes. |
 
 ### CT Connect SDK (`operation.route.ts`)
+
+> All routes below are defined bare in `operation.route.ts` and registered under the `/operations` prefix in `operation.plugin.ts:8`. The full paths are therefore `/operations/config`, `/operations/status`, `/operations/payment-components`, and `/operations/payment-intents/:id`.
 
 | Endpoint | Auth | Purpose |
 | --- | --- | --- |

--- a/context/known-issues.md
+++ b/context/known-issues.md
@@ -33,7 +33,7 @@ Connector-specific limitations, code defects, and operational gotchas. Cross-cut
 
 ## KI-004: `handleRequest()` in `actions.ts` does not await async post-deploy functions
 
-**Problem:** `handleRequest()` at `processor/src/connectors/actions.ts:32` is async but the functions it invokes (`createCustomerIdCustomType()`, `createLaunchpadPurchaseOrderNumberCustomType()`, etc.) are awaited only partially — the top-level caller of `handleRequest` does not await its result. Post-deploy functions may fail silently and the deploy succeeds regardless.
+**Problem:** `handleRequest()` at `processor/src/connectors/actions.ts:32` is async but the functions it invokes (`createOrUpdateCustomerCustomType()`, `createLaunchpadPurchaseOrderNumberCustomType()`, etc.) are awaited only partially — the top-level caller of `handleRequest` does not await its result. Post-deploy functions may fail silently and the deploy succeeds regardless.
 **Root cause:** `processor/src/connectors/actions.ts:32` — missing await on async function call.
 **Rule:** All async post-deploy lifecycle functions must be awaited with their errors propagated to the CT Connect SDK to fail the deploy.
 **Implementation note:** If a custom type creation fails silently, the connector starts without the required custom type and runtime calls that depend on it produce confusing errors.


### PR DESCRIPTION
Corrects two doc-audit findings in commercetools-stripe-integration:
- ARCHITECTURE.md: /config-element/payment and /operations/config were documented as literal routes; the actual routes are parameterized (/config-element/:paymentComponent) and prefixed at the plugin level (/operations prefix applied in operation.plugin.ts, not in the route file)
- known-issues.md (KI-004): referenced createCustomerIdCustomType(), which does not exist; the real function is createOrUpdateCustomerCustomType()